### PR TITLE
Fix PN_CHARS regex unclosed character class

### DIFF
--- a/src/Constant.php
+++ b/src/Constant.php
@@ -23,7 +23,7 @@ class Constant
     /**
      * @see https://www.w3.org/TR/rdf-sparql-query/#rPN_CHARS.
      */
-    const PN_CHARS = self::PN_CHARS_U . '|-|[0-9]|\x{00B7}|[\x{0300}-\x{036F}|[\x{203F}-\x{2040}]';
+    const PN_CHARS = self::PN_CHARS_U . '|-|[0-9]|\x{00B7}|[\x{0300}-\x{036F}]|[\x{203F}-\x{2040}]';
 
     /**
      * @see https://www.w3.org/TR/sparql11-query/#rVARNAME.


### PR DESCRIPTION
## Summary
- Closes #7
- Adds missing closing `]` to the `[\x{0300}-\x{036F}` character class in `Constant::PN_CHARS`
- Without the fix, the `|` after `\x{036F}` was treated as a literal inside the character class rather than an alternation operator, breaking prefix and local-part validation for inputs in that Unicode range

## Test plan
- [x] Existing test suite passes (`php vendor/bin/phpunit`)