### PR TITLE
Handle blank node bindings in SparQlResultDenormalizer

### DIFF
--- a/src/Serializer/Normalizer/SparQlResultDenormalizer.php
+++ b/src/Serializer/Normalizer/SparQlResultDenormalizer.php
@@ -6,6 +6,7 @@ use EffectiveActivism\SparQlClient\Constant;
 use EffectiveActivism\SparQlClient\Exception\InvalidResultException;
 use EffectiveActivism\SparQlClient\Syntax\Term\Iri\Iri;
 use EffectiveActivism\SparQlClient\Syntax\Term\Iri\PrefixedIri;
+use EffectiveActivism\SparQlClient\Syntax\Term\BlankNode\BlankNode;
 use EffectiveActivism\SparQlClient\Syntax\Term\Literal\PlainLiteral;
 use EffectiveActivism\SparQlClient\Syntax\Term\Literal\TypedLiteral;
 use EffectiveActivism\SparQlClient\Syntax\Term\TermInterface;
@@ -98,6 +99,9 @@ class SparQlResultDenormalizer implements DenormalizerInterface
             else {
                 throw new InvalidResultException(sprintf('Result "%s" is not a valid uri', $termData['uri']));
             }
+        }
+        elseif (isset($termData['bnode'])) {
+            return new BlankNode($termData['bnode']);
         }
         throw new InvalidResultException(sprintf('Result type "%s" is not a valid type', key($termData)));
     }

--- a/tests/Serializer/Normalizer/SparQlResultDenormalizerTest.php
+++ b/tests/Serializer/Normalizer/SparQlResultDenormalizerTest.php
@@ -4,6 +4,7 @@ namespace EffectiveActivism\SparQlClient\Tests\Serializer\Normalizer;
 
 use EffectiveActivism\SparQlClient\Exception\InvalidResultException;
 use EffectiveActivism\SparQlClient\Serializer\Normalizer\SparQlResultDenormalizer;
+use EffectiveActivism\SparQlClient\Syntax\Term\BlankNode\BlankNode;
 use EffectiveActivism\SparQlClient\Syntax\Term\Iri\Iri;
 use EffectiveActivism\SparQlClient\Syntax\Term\Literal\PlainLiteral;
 use EffectiveActivism\SparQlClient\Syntax\Term\Literal\TypedLiteral;
@@ -120,6 +121,22 @@ class SparQlResultDenormalizerTest extends KernelTestCase
         $term = array_shift($set);
         $this->assertInstanceOf(PlainLiteral::class, $term);
         $this->assertEquals('"""Ipsum"""', $term->serialize());
+    }
+
+    /**
+     * @covers \EffectiveActivism\SparQlClient\Serializer\Normalizer\SparQlResultDenormalizer
+     */
+    public function testBlankNode()
+    {
+        $data = file_get_contents(__DIR__ . '/../../fixtures/normalizer-blank-node.xml');
+        $denormalizedData = $this->serializer->deserialize($data, SparQlResultDenormalizer::TYPE, 'xml');
+        $this->assertCount(1, $denormalizedData);
+        $set = array_shift($denormalizedData);
+        $this->assertCount(1, $set);
+        /** @var TermInterface $term */
+        $term = array_pop($set);
+        $this->assertInstanceOf(BlankNode::class, $term);
+        $this->assertEquals('_:b1', $term->serialize());
     }
 
     public function testNormalizerExceptions()

--- a/tests/fixtures/normalizer-blank-node.xml
+++ b/tests/fixtures/normalizer-blank-node.xml
@@ -1,0 +1,13 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<sparql xmlns='http://www.w3.org/2005/sparql-results#'>
+    <head>
+        <variable name='subject'/>
+    </head>
+    <results>
+        <result>
+            <binding name='subject'>
+                <bnode>b1</bnode>
+            </binding>
+        </result>
+    </results>
+</sparql>


### PR DESCRIPTION
## Summary
- Closes #10
- Added `bnode` branch to `getTerm()` that returns a `BlankNode` instance, covering the third SPARQL 1.1 binding value type (`uri`, `literal`, `bnode`)
- Added `BlankNode` import to the denormalizer
- Added `testBlankNode` test with a fixture returning a `<bnode>b1</bnode>` binding

## Test plan
- [x] All existing tests pass (`php vendor/bin/phpunit`)