### PR TITLE
Add describe() to SparQlClientInterface

### DIFF
--- a/src/Client/SparQlClient.php
+++ b/src/Client/SparQlClient.php
@@ -15,6 +15,7 @@ use EffectiveActivism\SparQlClient\Syntax\Statement\ConstructStatementInterface;
 use EffectiveActivism\SparQlClient\Syntax\Statement\DeleteStatement;
 use EffectiveActivism\SparQlClient\Syntax\Statement\DeleteStatementInterface;
 use EffectiveActivism\SparQlClient\Syntax\Statement\DescribeStatement;
+use EffectiveActivism\SparQlClient\Syntax\Statement\DescribeStatementInterface;
 use EffectiveActivism\SparQlClient\Syntax\Statement\InsertStatementInterface;
 use EffectiveActivism\SparQlClient\Syntax\Statement\ReplaceStatement;
 use EffectiveActivism\SparQlClient\Syntax\Statement\ReplaceStatementInterface;
@@ -272,7 +273,7 @@ class SparQlClient implements SparQlClientInterface
     /**
      * @throws SparQlException
      */
-    protected function handleDescribeStatement(DescribeStatement $statement): array
+    protected function handleDescribeStatement(DescribeStatementInterface $statement): array
     {
         $query = $statement->toQuery();
         $this->logger->debug($query);

--- a/src/Client/SparQlClientInterface.php
+++ b/src/Client/SparQlClientInterface.php
@@ -5,6 +5,7 @@ namespace EffectiveActivism\SparQlClient\Client;
 use EffectiveActivism\SparQlClient\Syntax\Statement\AskStatementInterface;
 use EffectiveActivism\SparQlClient\Syntax\Statement\ConstructStatementInterface;
 use EffectiveActivism\SparQlClient\Syntax\Statement\DeleteStatementInterface;
+use EffectiveActivism\SparQlClient\Syntax\Statement\DescribeStatementInterface;
 use EffectiveActivism\SparQlClient\Syntax\Statement\InsertStatementInterface;
 use EffectiveActivism\SparQlClient\Syntax\Statement\ReplaceStatementInterface;
 use EffectiveActivism\SparQlClient\Syntax\Statement\SelectStatementInterface;
@@ -24,6 +25,8 @@ interface SparQlClientInterface
     public function insert(array $triples): InsertStatementInterface;
 
     public function replace(array $triples): ReplaceStatementInterface;
+
+    public function describe(array $resources): DescribeStatementInterface;
 
     public function select(array $variables): SelectStatementInterface;
 


### PR DESCRIPTION
## Summary
- Closes #11
- Added `describe(array $resources): DescribeStatementInterface` to `SparQlClientInterface`, making the method accessible to code typed against the interface
- Added `DescribeStatementInterface` import to `SparQlClientInterface`
- Changed `handleDescribeStatement(DescribeStatement $statement)` parameter type to `DescribeStatementInterface` in `SparQlClient`
- Added `DescribeStatementInterface` import to `SparQlClient`

## Test plan
- [x] All existing tests pass (`php vendor/bin/phpunit`)