### PR TITLE
Replace get_class() === ClassName::class with instanceof throughout

### DIFF
--- a/src/Client/SparQlClient.php
+++ b/src/Client/SparQlClient.php
@@ -139,13 +139,13 @@ class SparQlClient implements SparQlClientInterface
                     if ($condition instanceof TripleInterface) {
                         /** @var TermInterface $term */
                         foreach ($set as $term) {
-                            if (get_class($condition->getSubject()) === Variable::class && $condition->getSubject()->getVariableName() === $term->getVariableName()) {
+                            if ($condition->getSubject() instanceof Variable && $condition->getSubject()->getVariableName() === $term->getVariableName()) {
                                 $condition->setSubject($term);
                             }
-                            if (get_class($condition->getPredicate()) === Variable::class && $condition->getPredicate()->getVariableName() === $term->getVariableName()) {
+                            if ($condition->getPredicate() instanceof Variable && $condition->getPredicate()->getVariableName() === $term->getVariableName()) {
                                 $condition->setPredicate($term);
                             }
-                            if (get_class($condition->getObject()) === Variable::class && $condition->getObject()->getVariableName() === $term->getVariableName()) {
+                            if ($condition->getObject() instanceof Variable && $condition->getObject()->getVariableName() === $term->getVariableName()) {
                                 $condition->setObject($term);
                             }
                         }

--- a/src/Syntax/Statement/DescribeStatement.php
+++ b/src/Syntax/Statement/DescribeStatement.php
@@ -66,7 +66,7 @@ class DescribeStatement extends AbstractConditionalStatement implements Describe
                     $hasVariables = true;
                     foreach ($this->conditions as $condition) {
                         foreach ($condition->getTerms() as $clausedTerm) {
-                            if (get_class($clausedTerm) === Variable::class && $clausedTerm->getVariableName() === $term->getVariableName()) {
+                            if ($clausedTerm instanceof Variable && $clausedTerm->getVariableName() === $term->getVariableName()) {
                                 $unclausedVariables = false;
                                 break 3;
                             }

--- a/src/Syntax/Statement/InsertStatement.php
+++ b/src/Syntax/Statement/InsertStatement.php
@@ -50,11 +50,11 @@ class InsertStatement extends AbstractConditionalStatement implements InsertStat
             $hasVariables = false;
             foreach ($this->triplesToInsert as $triple) {
                 foreach ($triple->getTerms() as $term) {
-                    if (get_class($term) === Variable::class) {
+                    if ($term instanceof Variable) {
                         $hasVariables = true;
                         foreach ($this->conditions as $condition) {
                             foreach ($condition->getTerms() as $clausedTerm) {
-                                if (get_class($clausedTerm) === Variable::class && $clausedTerm->getVariableName() === $term->getVariableName()) {
+                                if ($clausedTerm instanceof Variable && $clausedTerm->getVariableName() === $term->getVariableName()) {
                                     $unclausedVariables = false;
                                     break 4;
                                 }
@@ -75,7 +75,7 @@ class InsertStatement extends AbstractConditionalStatement implements InsertStat
             // Variables are not allowed when not using 'where' clauses.
             foreach ($this->triplesToInsert as $triple) {
                 foreach ($triple->getTerms() as $term) {
-                    if (get_class($term) === Variable::class) {
+                    if ($term instanceof Variable) {
                         throw new SparQlException(sprintf('Variable "%s" cannot be inserted without being referenced in a \'where\' clause', $term->getVariableName()));
                     }
                 }

--- a/src/Syntax/Statement/ReplaceStatement.php
+++ b/src/Syntax/Statement/ReplaceStatement.php
@@ -77,11 +77,11 @@ class ReplaceStatement extends AbstractConditionalStatement implements ReplaceSt
         $hasVariables = false;
         foreach (array_merge($this->originals, $this->replacements) as $triple) {
             foreach ($triple->getTerms() as $term) {
-                if (get_class($term) === Variable::class) {
+                if ($term instanceof Variable) {
                     $hasVariables = true;
                     foreach ($this->conditions as $condition) {
                         foreach ($condition->getTerms() as $clausedTerm) {
-                            if (get_class($clausedTerm) === Variable::class && $clausedTerm->getVariableName() === $term->getVariableName()) {
+                            if ($clausedTerm instanceof Variable && $clausedTerm->getVariableName() === $term->getVariableName()) {
                                 $unclausedVariables = false;
                                 break 4;
                             }

--- a/src/Syntax/Statement/SelectStatement.php
+++ b/src/Syntax/Statement/SelectStatement.php
@@ -59,7 +59,7 @@ class SelectStatement extends AbstractConditionalStatement implements SelectStat
             foreach ($this->variables as $term) {
                 foreach ($this->conditions as $condition) {
                     foreach ($condition->getTerms() as $clausedTerm) {
-                        if (get_class($clausedTerm) === Variable::class && $clausedTerm->getVariableName() === $term->getVariableName()) {
+                        if ($clausedTerm instanceof Variable && $clausedTerm->getVariableName() === $term->getVariableName()) {
                             $unclausedVariables = false;
                             break 3;
                         }


### PR DESCRIPTION
## Summary
- Closes #13
- Replaced all `get_class($x) === SomeClass::class` comparisons with `$x instanceof SomeClass` in the five locations identified in the issue
- Affected files: `SparQlClient.php` (3 checks in `handleQueryStatement`), `SelectStatement.php`, `DescribeStatement.php`, `InsertStatement.php` (3 checks), `ReplaceStatement.php` (2 checks)

## Test plan
- [x] All existing tests pass (`php vendor/bin/phpunit`) — 174 tests, 426 assertions

🤖 Generated with [Claude Code](https://claude.com/claude-code)