### PR TITLE
Fix namespace prefix validation to use PN_PREFIX instead of PN_LOCAL

### DIFF
--- a/src/Syntax/Statement/AbstractStatement.php
+++ b/src/Syntax/Statement/AbstractStatement.php
@@ -16,7 +16,7 @@ abstract class AbstractStatement implements StatementInterface
     {
         // Validate extra namespaces.
         foreach ($namespaces as $prefix => $url) {
-            if (!is_string($prefix) || !preg_match(sprintf('/%s/u', Constant::PN_LOCAL), $prefix)) {
+            if (!is_string($prefix) || !preg_match(sprintf('/%s/u', Constant::PN_PREFIX), $prefix)) {
                 throw new SparQlException(sprintf('Value "%s" is not a valid prefix', $prefix));
             }
             if (!filter_var($url, FILTER_VALIDATE_URL)) {


### PR DESCRIPTION
## Summary
- Closes #15
- Changed `AbstractStatement::__construct()` to validate namespace prefixes against `Constant::PN_PREFIX` instead of `Constant::PN_LOCAL`
- `PN_LOCAL` permits `:` and leading digits, which are illegal in SPARQL prefix labels; `PN_PREFIX` correctly models the grammar rule for `PREFIX` declarations

## Test plan
- [x] All existing tests pass (`php vendor/bin/phpunit`) — 174 tests, 426 assertions