### PR TITLE
Remove duplicate ExceptionInterface import in SparQlClient

### DIFF
--- a/src/Client/SparQlClient.php
+++ b/src/Client/SparQlClient.php
@@ -34,7 +34,6 @@ use Symfony\Component\Serializer\Serializer;
 use Symfony\Component\Serializer\SerializerInterface;
 use Symfony\Contracts\Cache\ItemInterface;
 use Symfony\Contracts\Cache\TagAwareCacheInterface;
-use Symfony\Contracts\HttpClient\Exception\ExceptionInterface;
 use Symfony\Contracts\HttpClient\Exception\ExceptionInterface as HttpClientExceptionInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
@@ -367,7 +366,7 @@ class SparQlClient implements SparQlClientInterface
                 'body' => $file->getContent(),
             ]);
             return true;
-        } catch (ExceptionInterface $exception) {
+        } catch (HttpClientExceptionInterface $exception) {
             throw new SparQlException($exception->getMessage(), $exception->getCode(), $exception);
         }
     }


### PR DESCRIPTION
## Summary
- Closes #17
- Removed the unaliased `use Symfony\Contracts\HttpClient\Exception\ExceptionInterface` import
- Updated the one usage in `upload()` from `ExceptionInterface` to `HttpClientExceptionInterface`
- All usages now consistently use the aliased form, which makes the origin clearer

## Test plan
- [x] All existing tests pass (`php vendor/bin/phpunit`) — 174 tests, 426 assertions