### PR TITLE
Make per-row cache tagging cheap and opt-out

### DIFF
--- a/src/Client/CacheTrait.php
+++ b/src/Client/CacheTrait.php
@@ -17,6 +17,13 @@ trait CacheTrait
         return Uuid::uuid5(Constant::NAMESPACE_CACHE, $value)->toString();
     }
 
+    /**
+     * Extracts cache tags from patterns. The accumulator is keyed by the
+     * serialized term so a given IRI/literal yields at most one UUID5 call
+     * per call chain — keeping per-row tagging tractable when SELECT/CONSTRUCT
+     * results contain repeated values (predicates, type IRIs, common objects).
+     * Callers iterate values, so the key shape is internal.
+     */
     protected function extractTags(array $patterns, array $tags = []): array
     {
         /** @var PatternInterface $pattern */
@@ -25,7 +32,10 @@ trait CacheTrait
                 $pattern instanceof AbstractIri ||
                 $pattern instanceof AbstractLiteral
             ) {
-                $tags[] = $this->getKey($pattern->serialize());
+                $serialized = $pattern->serialize();
+                if (!isset($tags[$serialized])) {
+                    $tags[$serialized] = $this->getKey($serialized);
+                }
             }
             elseif ($pattern instanceof TripleInterface) {
                 $tags = $this->extractTags([$pattern->getSubject(), $pattern->getObject()], $tags);

--- a/src/Client/SparQlClient.php
+++ b/src/Client/SparQlClient.php
@@ -132,8 +132,10 @@ class SparQlClient implements SparQlClientInterface
                 }
                 $rows = $this->serializer->deserialize($responseContent, SparQlResultDenormalizer::TYPE, 'xml');
                 $tags = $this->extractTags($statement->getConditions());
-                foreach ($rows as $row) {
-                    $tags = $this->extractTags($row, $tags);
+                if ($statement->tagsResults()) {
+                    foreach ($rows as $row) {
+                        $tags = $this->extractTags($row, $tags);
+                    }
                 }
                 $item->tag($tags);
                 return $responseContent;
@@ -222,8 +224,10 @@ class SparQlClient implements SparQlClientInterface
                 }
                 $tripleArrays = $this->serializer->deserialize($responseContent, SparQlConstructDenormalizer::TYPE, 'xml');
                 $tags = $this->extractTags($statement->getConditions());
-                foreach ($tripleArrays as $tripleArray) {
-                    $tags = $this->extractTags($tripleArray, $tags);
+                if ($statement->tagsResults()) {
+                    foreach ($tripleArrays as $tripleArray) {
+                        $tags = $this->extractTags($tripleArray, $tags);
+                    }
                 }
                 $item->tag($tags);
                 return $responseContent;
@@ -297,8 +301,10 @@ class SparQlClient implements SparQlClientInterface
                 }
                 $tripleArrays = $this->serializer->deserialize($responseContent, SparQlConstructDenormalizer::TYPE, 'xml');
                 $tags = $this->extractTags(array_merge($statement->getResources(), $statement->getConditions()));
-                foreach ($tripleArrays as $tripleArray) {
-                    $tags = $this->extractTags($tripleArray, $tags);
+                if ($statement->tagsResults()) {
+                    foreach ($tripleArrays as $tripleArray) {
+                        $tags = $this->extractTags($tripleArray, $tags);
+                    }
                 }
                 $item->tag($tags);
                 return $responseContent;

--- a/src/Syntax/Statement/ConstructStatement.php
+++ b/src/Syntax/Statement/ConstructStatement.php
@@ -8,6 +8,8 @@ use EffectiveActivism\SparQlClient\Syntax\Pattern\Triple\TripleInterface;
 
 class ConstructStatement extends AbstractConditionalStatement implements ConstructStatementInterface
 {
+    use ResultTaggingTrait;
+
     protected array $triplesToConstruct;
 
     /**

--- a/src/Syntax/Statement/ConstructStatementInterface.php
+++ b/src/Syntax/Statement/ConstructStatementInterface.php
@@ -2,7 +2,7 @@
 
 namespace EffectiveActivism\SparQlClient\Syntax\Statement;
 
-interface ConstructStatementInterface extends ConditionalStatementInterface
+interface ConstructStatementInterface extends ConditionalStatementInterface, ResultTaggableInterface
 {
     public function __construct(array $triples);
 

--- a/src/Syntax/Statement/DescribeStatement.php
+++ b/src/Syntax/Statement/DescribeStatement.php
@@ -10,6 +10,8 @@ use EffectiveActivism\SparQlClient\Syntax\Term\Variable\Variable;
 
 class DescribeStatement extends AbstractConditionalStatement implements DescribeStatementInterface
 {
+    use ResultTaggingTrait;
+
     protected int $limit = 0;
 
     protected int $offset = 0;

--- a/src/Syntax/Statement/DescribeStatementInterface.php
+++ b/src/Syntax/Statement/DescribeStatementInterface.php
@@ -2,7 +2,7 @@
 
 namespace EffectiveActivism\SparQlClient\Syntax\Statement;
 
-interface DescribeStatementInterface extends ConditionalStatementInterface
+interface DescribeStatementInterface extends ConditionalStatementInterface, ResultTaggableInterface
 {
     public function __construct(array $resources);
 

--- a/src/Syntax/Statement/ResultTaggableInterface.php
+++ b/src/Syntax/Statement/ResultTaggableInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace EffectiveActivism\SparQlClient\Syntax\Statement;
+
+interface ResultTaggableInterface
+{
+    /**
+     * Disable per-row cache tagging for this statement. Structural tags
+     * derived from the query pattern still apply; only result-derived tags
+     * are skipped. Use this for aggregate or large-result queries where the
+     * UUID5-per-binding cost of per-row tagging dominates wall time.
+     */
+    public function withoutResultTags(): static;
+
+    public function tagsResults(): bool;
+}

--- a/src/Syntax/Statement/ResultTaggingTrait.php
+++ b/src/Syntax/Statement/ResultTaggingTrait.php
@@ -1,0 +1,19 @@
+<?php declare(strict_types=1);
+
+namespace EffectiveActivism\SparQlClient\Syntax\Statement;
+
+trait ResultTaggingTrait
+{
+    protected bool $tagResults = true;
+
+    public function withoutResultTags(): static
+    {
+        $this->tagResults = false;
+        return $this;
+    }
+
+    public function tagsResults(): bool
+    {
+        return $this->tagResults;
+    }
+}

--- a/src/Syntax/Statement/SelectStatement.php
+++ b/src/Syntax/Statement/SelectStatement.php
@@ -10,6 +10,8 @@ use EffectiveActivism\SparQlClient\Syntax\Term\Variable\Variable;
 
 class SelectStatement extends AbstractConditionalStatement implements SelectStatementInterface
 {
+    use ResultTaggingTrait;
+
     protected int $limit = 0;
 
     protected int $offset = 0;

--- a/src/Syntax/Statement/SelectStatementInterface.php
+++ b/src/Syntax/Statement/SelectStatementInterface.php
@@ -4,7 +4,7 @@ namespace EffectiveActivism\SparQlClient\Syntax\Statement;
 
 use EffectiveActivism\SparQlClient\Syntax\Pattern\Constraint\Operator\OperatorInterface;
 
-interface SelectStatementInterface extends ConditionalStatementInterface
+interface SelectStatementInterface extends ConditionalStatementInterface, ResultTaggableInterface
 {
     public function __construct(array $variables);
 

--- a/tests/Client/SparQlClientTest.php
+++ b/tests/Client/SparQlClientTest.php
@@ -1488,4 +1488,92 @@ class SparQlClientTest extends KernelTestCase
             $this->assertEquals('http://test-sparql-endpoint:9999/blazegraph/sparql', $receivedUrl, "Update operation '$type' should hit update_endpoint");
         }
     }
+
+    /**
+     * Baseline: per-row tagging is enabled by default, so a write that
+     * touches an IRI which only appears in result rows (not in the SELECT
+     * conditions) still invalidates the cached SELECT entry.
+     */
+    public function testCachingInvalidationByRowLevelIri()
+    {
+        $cacheAdapter = new TagAwareAdapter(new ArrayAdapter());
+        $selectResponseContent = file_get_contents(__DIR__ . '/../fixtures/client-select-request.xml');
+        $httpClient = new MockHttpClient([new MockResponse($selectResponseContent), new MockResponse('')]);
+        $kernel = new TestKernel('test', true);
+        $kernel->boot();
+        $kernel->getContainer()->set(TagAwareCacheInterface::class, $cacheAdapter);
+        $kernel->getContainer()->set(HttpClientInterface::class, $httpClient);
+        /** @var SparQlClientInterface $sparQlClient */
+        $sparQlClient = $kernel->getContainer()->get(SparQlClientInterface::class);
+        $subject = new Variable('subject');
+        $predicate = new PrefixedIri('schema', 'headline');
+        $object = new PrefixedIri('schema', 'Article');
+        $sparQlClient->execute($sparQlClient->select([$subject])->withNamespaces(['schema' => 'http://schema.org/'])->where([new Triple($subject, $predicate, $object)]));
+        // Row-level subject from client-select-request.xml; not present in the SELECT conditions.
+        $rowSubject = new Iri('urn:uuid:fcf19bc4-7e81-11eb-a169-175604c7c7bc');
+        $unrelatedPredicate = new PrefixedIri('schema', 'about');
+        $unrelatedObject = new Variable('thing');
+        $writeTriple = new Triple($rowSubject, $unrelatedPredicate, $unrelatedObject);
+        $sparQlClient->execute($sparQlClient->delete([$writeTriple])->withNamespaces(['schema' => 'http://schema.org/'])->where([$writeTriple]));
+        $this->assertEquals('UNCACHED', $cacheAdapter->get(self::HASHED_QUERY_UUID, function (ItemInterface $item) {
+            return 'UNCACHED';
+        }));
+    }
+
+    /**
+     * withoutResultTags() suppresses the per-row tag walk, so a write
+     * targeting an IRI that only appeared in result rows no longer
+     * invalidates the cached SELECT entry. Structural condition tags
+     * still apply and would still invalidate via overlapping conditions.
+     */
+    public function testWithoutResultTagsSkipsPerRowTagging()
+    {
+        $cacheAdapter = new TagAwareAdapter(new ArrayAdapter());
+        $selectResponseContent = file_get_contents(__DIR__ . '/../fixtures/client-select-request.xml');
+        $httpClient = new MockHttpClient([new MockResponse($selectResponseContent), new MockResponse('')]);
+        $kernel = new TestKernel('test', true);
+        $kernel->boot();
+        $kernel->getContainer()->set(TagAwareCacheInterface::class, $cacheAdapter);
+        $kernel->getContainer()->set(HttpClientInterface::class, $httpClient);
+        /** @var SparQlClientInterface $sparQlClient */
+        $sparQlClient = $kernel->getContainer()->get(SparQlClientInterface::class);
+        $subject = new Variable('subject');
+        $predicate = new PrefixedIri('schema', 'headline');
+        $object = new PrefixedIri('schema', 'Article');
+        $sparQlClient->execute($sparQlClient->select([$subject])->withoutResultTags()->withNamespaces(['schema' => 'http://schema.org/'])->where([new Triple($subject, $predicate, $object)]));
+        $rowSubject = new Iri('urn:uuid:fcf19bc4-7e81-11eb-a169-175604c7c7bc');
+        $unrelatedPredicate = new PrefixedIri('schema', 'about');
+        $unrelatedObject = new Variable('thing');
+        $writeTriple = new Triple($rowSubject, $unrelatedPredicate, $unrelatedObject);
+        $sparQlClient->execute($sparQlClient->delete([$writeTriple])->withNamespaces(['schema' => 'http://schema.org/'])->where([$writeTriple]));
+        $this->assertEquals($selectResponseContent, $cacheAdapter->get(self::HASHED_QUERY_UUID, function (ItemInterface $item) {
+            return 'UNCACHED';
+        }));
+    }
+
+    /**
+     * tagsResults() reports the configured value; default is true.
+     */
+    public function testTagsResultsFlag()
+    {
+        $kernel = new TestKernel('test', true);
+        $kernel->boot();
+        $kernel->getContainer()->set(TagAwareCacheInterface::class, new TagAwareAdapter(new ArrayAdapter()));
+        $kernel->getContainer()->set(HttpClientInterface::class, new MockHttpClient());
+        /** @var SparQlClientInterface $sparQlClient */
+        $sparQlClient = $kernel->getContainer()->get(SparQlClientInterface::class);
+        $variable = new Variable('subject');
+        $select = $sparQlClient->select([$variable]);
+        $this->assertTrue($select->tagsResults());
+        $select->withoutResultTags();
+        $this->assertFalse($select->tagsResults());
+        $construct = $sparQlClient->construct([new Triple($variable, new PrefixedIri('schema', 'headline'), new Variable('object'))]);
+        $this->assertTrue($construct->tagsResults());
+        $construct->withoutResultTags();
+        $this->assertFalse($construct->tagsResults());
+        $describe = $sparQlClient->describe([$variable]);
+        $this->assertTrue($describe->tagsResults());
+        $describe->withoutResultTags();
+        $this->assertFalse($describe->tagsResults());
+    }
 }

--- a/tests/Client/SparQlClientTest.php
+++ b/tests/Client/SparQlClientTest.php
@@ -1493,6 +1493,10 @@ class SparQlClientTest extends KernelTestCase
      * Baseline: per-row tagging is enabled by default, so a write that
      * touches an IRI which only appears in result rows (not in the SELECT
      * conditions) still invalidates the cached SELECT entry.
+     *
+     * @covers \EffectiveActivism\SparQlClient\Client\SparQlClient
+     * @covers \EffectiveActivism\SparQlClient\Client\CacheTrait
+     * @covers \EffectiveActivism\SparQlClient\Syntax\Statement\ResultTaggingTrait
      */
     public function testCachingInvalidationByRowLevelIri()
     {
@@ -1525,6 +1529,10 @@ class SparQlClientTest extends KernelTestCase
      * targeting an IRI that only appeared in result rows no longer
      * invalidates the cached SELECT entry. Structural condition tags
      * still apply and would still invalidate via overlapping conditions.
+     *
+     * @covers \EffectiveActivism\SparQlClient\Client\SparQlClient
+     * @covers \EffectiveActivism\SparQlClient\Client\CacheTrait
+     * @covers \EffectiveActivism\SparQlClient\Syntax\Statement\ResultTaggingTrait
      */
     public function testWithoutResultTagsSkipsPerRowTagging()
     {
@@ -1553,6 +1561,11 @@ class SparQlClientTest extends KernelTestCase
 
     /**
      * tagsResults() reports the configured value; default is true.
+     *
+     * @covers \EffectiveActivism\SparQlClient\Syntax\Statement\ResultTaggingTrait
+     * @covers \EffectiveActivism\SparQlClient\Syntax\Statement\SelectStatement
+     * @covers \EffectiveActivism\SparQlClient\Syntax\Statement\ConstructStatement
+     * @covers \EffectiveActivism\SparQlClient\Syntax\Statement\DescribeStatement
      */
     public function testTagsResultsFlag()
     {


### PR DESCRIPTION
## Summary

- Dedup `extractTags` on serialized term, dropping the SHA-1 cost from O(rows × bindings) to O(unique terms). Same query that hit `max_execution_time` after Fuseki returned now only pays for distinct IRIs/literals.
- New `withoutResultTags()` (Select/Construct/Describe) suppresses the per-row tag walk entirely. Structural condition tags still apply — sufficient invalidation precision when any write to the matched pattern would evict the entry anyway, and the only real escape hatch when a result set is large enough that even a deduped walk is undesired bookkeeping.
- Default behavior is unchanged: per-row tagging stays on.

## Test plan

- [x] `vendor/bin/phpunit` green (448 tests).
- [x] `testCachingInvalidationByRowLevelIri` confirms a write touching only a row-level IRI still evicts the cached SELECT under default tagging.
- [x] `testWithoutResultTagsSkipsPerRowTagging` confirms the same write leaves the cache intact when `withoutResultTags()` was set on the SELECT.
- [x] `testTagsResultsFlag` checks default + toggle on Select/Construct/Describe.

Closes #53