### PR TITLE
Document FunctionCall and align operation lists in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # SparQl client
 
-An OOP SPARQL 1.1 client for Symfony with support for SELECT, CONSTRUCT, ASK,
-DESCRIBE, DELETE, INSERT and DELETE+INSERT operations. Includes graph patterns,
-aggregates, scalar functions, dataset clauses, and term, namespace and statement
+An OOP SPARQL 1.1 client for Symfony with support for SELECT, ASK, CONSTRUCT,
+DESCRIBE, INSERT, DELETE, DELETE+INSERT, CLEAR, DROP, CREATE, LOAD, COPY, MOVE
+and ADD operations. Includes graph patterns, aggregates, scalar functions,
+extension function calls, dataset clauses, and term, namespace and statement
 validation.
 
 ## Table of content
@@ -38,6 +39,7 @@ validation.
     - [Constraints](#constraints)
         - [Filter examples](#filter-examples)
     - [Aggregates](#aggregates)
+    - [Extension functions](#extension-functions)
     - [Error handling](#error-handling)
 - [SHACL validator](#shacl-validator)
 - [Example docker-compose setup](#example-docker-compose-setup)
@@ -53,8 +55,8 @@ composer require effectiveactivism/sparql-client
 
 This bundle requires two SPARQL endpoints: one for query operations
 (SELECT, ASK, CONSTRUCT, DESCRIBE) and one for update operations
-(INSERT, DELETE, CLEAR, DROP, CREATE, REPLACE). You can also optionally
-define a SHACL endpoint.
+(INSERT, DELETE, DELETE+INSERT via `replace()`, CLEAR, DROP, CREATE,
+LOAD, COPY, MOVE, ADD). You can also optionally define a SHACL endpoint.
 
 For Blazegraph, both endpoints are the same URL:
 
@@ -876,6 +878,50 @@ $selectStatement = $sparQlClient
     ->where([$triple])
     ->groupBy([$subject]);
 ```
+
+### Extension functions
+
+`FunctionCall` invokes an arbitrary SPARQL extension function by IRI,
+covering GeoSPARQL, full-text search, and any triplestore-specific
+functions that don't have dedicated operator classes. It accepts any
+number of argument terms or operators (including zero) and can be
+nested inside other operators.
+
+```php
+<?php
+
+use EffectiveActivism\SparQlClient\Syntax\Pattern\Constraint\Filter;
+use EffectiveActivism\SparQlClient\Syntax\Pattern\Constraint\Operator\Binary\LessThan;
+use EffectiveActivism\SparQlClient\Syntax\Pattern\Constraint\Operator\FunctionCall;
+use EffectiveActivism\SparQlClient\Syntax\Term\Iri\PrefixedIri;
+use EffectiveActivism\SparQlClient\Syntax\Term\Literal\TypedLiteral;
+use EffectiveActivism\SparQlClient\Syntax\Term\Variable\Variable;
+
+$point1 = new Variable('point1');
+$point2 = new Variable('point2');
+
+// geof:distance(?point1, ?point2, uom:metre)
+$distance = new FunctionCall(
+    new PrefixedIri('geof', 'distance'),
+    $point1,
+    $point2,
+    new PrefixedIri('uom', 'metre'),
+);
+
+// Restrict results to pairs within 1000 metres of each other.
+$filter = new Filter(new LessThan($distance, new TypedLiteral(1000)));
+
+$selectStatement = $sparQlClient
+    ->select([$point1, $point2])
+    ->withNamespaces([
+        'geof' => 'http://www.opengis.net/def/function/geosparql/',
+        'uom' => 'http://www.opengis.net/def/uom/OGC/1.0/',
+    ])
+    ->where([$filter]);
+```
+
+`FunctionCall` accepts both prefixed IRIs (`geof:distance`) and full
+IRIs (`<http://example.org/func>`).
 
 ### Error handling
 


### PR DESCRIPTION
## Summary

Picks up the README work from #50 and applies the three Copilot review comments on it. Since #54 already landed an overlapping graph-management section on master, this PR carries forward only the parts of #50 that are still useful, so #50 can now be closed.

- Adds an **Extension functions** section documenting `FunctionCall`. The standalone example is self-contained — Copilot flagged that the original referenced an undefined `\$triple`, so the example now uses just `where([\$filter])`.
- Updates the opening operations list to cover what the client actually exposes today: `CLEAR`, `DROP`, `CREATE`, `LOAD`, `COPY`, `MOVE`, `ADD`. Also mentions extension function calls in the descriptors.
- Updates the configuration section to drop \"REPLACE\" — there is no SPARQL Update `REPLACE` keyword; the library's `replace()` serializes to `DELETE+INSERT`, which is what the section now says — and to add `LOAD`, `COPY`, `MOVE`, `ADD`.

## Test plan

- [x] No code changes; phpunit not affected.
- [x] TOC entry resolves to the new heading anchor.

Closes #50