### PR TITLE
Strip prologue and dataset clause from subquery serialization

### DIFF
--- a/src/Syntax/Pattern/Subquery/Subquery.php
+++ b/src/Syntax/Pattern/Subquery/Subquery.php
@@ -31,6 +31,6 @@ class Subquery implements SubqueryInterface
 
     public function serialize(): string
     {
-        return sprintf('{ %s }', $this->statement->toQuery());
+        return sprintf('{ %s }', $this->statement->toSubQuery());
     }
 }

--- a/src/Syntax/Statement/SelectStatement.php
+++ b/src/Syntax/Statement/SelectStatement.php
@@ -46,6 +46,28 @@ class SelectStatement extends AbstractConditionalStatement implements SelectStat
     {
         $this->validatePrefixes($this->conditions);
         $preQuery = parent::toQuery();
+        return trim($preQuery . $this->buildSelectBody($this->getDatasetClausesString()));
+    }
+
+    /**
+     * Serializes this statement as a SubSelect (SPARQL 1.1 grammar production
+     * `SubSelect`), suitable for inlining inside `{ … }` in another query.
+     * Omits the Prologue (BASE/PREFIX) and DatasetClause (FROM/FROM NAMED),
+     * neither of which are permitted inside a group graph pattern.
+     *
+     * @throws SparQlException
+     */
+    public function toSubQuery(): string
+    {
+        $this->validatePrefixes($this->conditions);
+        return $this->buildSelectBody('');
+    }
+
+    /**
+     * @throws SparQlException
+     */
+    private function buildSelectBody(string $datasetClauses): string
+    {
         $variables = '';
         foreach ($this->variables as $variable) {
             $variables .= sprintf('%s ', $variable->serialize());
@@ -53,6 +75,9 @@ class SelectStatement extends AbstractConditionalStatement implements SelectStat
         $conditionsString = '';
         foreach ($this->conditions as $condition) {
             $conditionsString .= sprintf(' %s .', $condition->serialize());
+        }
+        if (empty($conditionsString)) {
+            throw new SparQlException('Select statement is missing a \'where\' clause');
         }
         $limitString = '';
         if ($this->limit > 0) {
@@ -84,31 +109,24 @@ class SelectStatement extends AbstractConditionalStatement implements SelectStat
         } else {
             $modifier = '';
         }
-        if (!empty($conditionsString)) {
-            // Only check unclaused variables for plain Variable instances (SelectExpressionInterface items bind their own variables).
-            $plainVariables = array_filter($this->variables, fn($v) => $v instanceof Variable);
-            if (!empty($plainVariables)) {
-                $unclausedVariables = true;
-                foreach ($plainVariables as $term) {
-                    foreach ($this->conditions as $condition) {
-                        foreach ($condition->getTerms() as $clausedTerm) {
-                            if ($clausedTerm instanceof Variable && $clausedTerm->getVariableName() === $term->getVariableName()) {
-                                $unclausedVariables = false;
-                                break 3;
-                            }
+        $plainVariables = array_filter($this->variables, fn($v) => $v instanceof Variable);
+        if (!empty($plainVariables)) {
+            $unclausedVariables = true;
+            foreach ($plainVariables as $term) {
+                foreach ($this->conditions as $condition) {
+                    foreach ($condition->getTerms() as $clausedTerm) {
+                        if ($clausedTerm instanceof Variable && $clausedTerm->getVariableName() === $term->getVariableName()) {
+                            $unclausedVariables = false;
+                            break 3;
                         }
                     }
                 }
-                if ($unclausedVariables) {
-                    throw new SparQlException('At least one variable must be referenced in a \'where\' clause.');
-                }
             }
-            return trim(sprintf('%sSELECT %s%s%sWHERE {%s }%s%s%s%s%s', $preQuery, $modifier, $variables, $this->getDatasetClausesString(), $conditionsString, $groupByString, $havingString, $orderByString, $limitString, $offsetString));
+            if ($unclausedVariables) {
+                throw new SparQlException('At least one variable must be referenced in a \'where\' clause.');
+            }
         }
-        else {
-            // Select statements must have a 'where' clause.
-            throw new SparQlException('Select statement is missing a \'where\' clause');
-        }
+        return sprintf('SELECT %s%s%sWHERE {%s }%s%s%s%s%s', $modifier, $variables, $datasetClauses, $conditionsString, $groupByString, $havingString, $orderByString, $limitString, $offsetString);
     }
 
     /**

--- a/src/Syntax/Statement/SelectStatementInterface.php
+++ b/src/Syntax/Statement/SelectStatementInterface.php
@@ -25,4 +25,6 @@ interface SelectStatementInterface extends ConditionalStatementInterface, Result
     public function getVariables(): array;
 
     public function setVariables(array $variables): SelectStatementInterface;
+
+    public function toSubQuery(): string;
 }

--- a/tests/Syntax/Pattern/Subquery/SubqueryTest.php
+++ b/tests/Syntax/Pattern/Subquery/SubqueryTest.php
@@ -27,4 +27,29 @@ class SubqueryTest extends KernelTestCase
         $this->assertEquals([$subject, $predicate, $object], $subquery->getTerms());
         $this->assertEquals([$subject, $predicate, $object], $subquery->toArray());
     }
+
+    /**
+     * Regression: prologue (BASE/PREFIX) and dataset clauses (FROM/FROM NAMED)
+     * are illegal inside a group graph pattern, so a Subquery must not leak
+     * them from the inner statement's full toQuery() output.
+     */
+    public function testSubqueryOmitsPrologueAndDatasetClause()
+    {
+        $subject = new Variable('subject');
+        $predicate = new Iri('http://schema.org/headline');
+        $object = new PlainLiteral('Lorem');
+        $triple = new Triple($subject, $predicate, $object);
+        $statement = new SelectStatement([$subject]);
+        $statement
+            ->withNamespaces(['schema' => 'http://schema.org/'])
+            ->withBase('http://example.org/')
+            ->from(new Iri('http://example.org/graph'))
+            ->fromNamed(new Iri('http://example.org/named'))
+            ->where([$triple]);
+        $serialized = (new Subquery($statement))->serialize();
+        $this->assertStringNotContainsString('PREFIX', $serialized);
+        $this->assertStringNotContainsString('BASE', $serialized);
+        $this->assertStringNotContainsString('FROM', $serialized);
+        $this->assertEquals(self::SERIALIZED_VALUE, $serialized);
+    }
 }

--- a/tests/Syntax/Pattern/Subquery/SubqueryTest.php
+++ b/tests/Syntax/Pattern/Subquery/SubqueryTest.php
@@ -32,6 +32,9 @@ class SubqueryTest extends KernelTestCase
      * Regression: prologue (BASE/PREFIX) and dataset clauses (FROM/FROM NAMED)
      * are illegal inside a group graph pattern, so a Subquery must not leak
      * them from the inner statement's full toQuery() output.
+     *
+     * @covers \EffectiveActivism\SparQlClient\Syntax\Pattern\Subquery\Subquery
+     * @covers \EffectiveActivism\SparQlClient\Syntax\Statement\SelectStatement
      */
     public function testSubqueryOmitsPrologueAndDatasetClause()
     {


### PR DESCRIPTION
## Summary
- `Subquery::serialize()` previously wrapped the inner statement's full `toQuery()` output in `{ … }`, leaking `BASE` / `PREFIX` / `FROM` / `FROM NAMED` into a position where the SPARQL 1.1 grammar's `SubSelect` production permits none of them.
- Extracted a private `buildSelectBody()` helper on `SelectStatement`. Added `SelectStatementInterface::toSubQuery()` which emits the SubSelect form (no prologue, no dataset clause). `Subquery::serialize()` now calls it.
- Added a regression test that registers `withNamespaces`, `withBase`, `from`, and `fromNamed` on the inner statement and asserts none of `PREFIX` / `BASE` / `FROM` appear in the serialized subquery.

The pre-existing `SubqueryTest::testSubquery()` only passed because it constructed the inner statement without any of these — the bug was invisible until the inner statement actually had something to leak.

Closes #56

## Test plan
- [x] `vendor/bin/phpunit tests/Syntax/Pattern/Subquery/SubqueryTest.php` — 2 tests, 7 assertions, passing
- [x] `vendor/bin/phpunit` — full suite, 449 tests, 833 assertions, passing