### PR TITLE
Propagate subquery namespaces to outer prologue

### DIFF
--- a/README.md
+++ b/README.md
@@ -586,12 +586,25 @@ use EffectiveActivism\SparQlClient\Syntax\Term\Variable\Variable;
 
 $subject = new Variable('subject');
 $innerTriple = new Triple($subject, new PrefixedIri('schema', 'headline'), new Variable('headline'));
-$innerSelect = $sparQlClient->select([$subject])->where([$innerTriple]);
+$innerSelect = $sparQlClient->select([$subject])
+    ->withNamespaces(['schema' => 'http://schema.org/'])
+    ->where([$innerTriple]);
 $subquery = new Subquery($innerSelect);
 
 $outerTriple = new Triple($subject, new PrefixedIri('schema', 'name'), new Variable('name'));
 $outerSelect = $sparQlClient->select([$subject])->where([$subquery, $outerTriple]);
 ```
+
+Namespaces declared via `withNamespaces()` on an inner statement bubble up
+into the outer query's prologue, so the same prefix does not have to be
+repeated on the outer. Nested subqueries propagate the same way. If the
+inner and outer (or two sibling subqueries) bind the same prefix to
+different URLs, serialization throws `SparQlException`.
+
+Per the SPARQL 1.1 grammar, `BASE` / `PREFIX` / `FROM` / `FROM NAMED`
+declared on the inner statement do not appear in the embedded SubSelect —
+the outer prologue is authoritative; only the inner's `withNamespaces()`
+contribution is folded into it.
 
 ### Property paths and sets
 

--- a/src/Syntax/Pattern/Subquery/Subquery.php
+++ b/src/Syntax/Pattern/Subquery/Subquery.php
@@ -13,6 +13,11 @@ class Subquery implements SubqueryInterface
         $this->statement = $statement;
     }
 
+    public function getInnerStatement(): SelectStatementInterface
+    {
+        return $this->statement;
+    }
+
     public function toArray(): array
     {
         return $this->getTerms();

--- a/src/Syntax/Pattern/Subquery/SubqueryInterface.php
+++ b/src/Syntax/Pattern/Subquery/SubqueryInterface.php
@@ -3,7 +3,9 @@
 namespace EffectiveActivism\SparQlClient\Syntax\Pattern\Subquery;
 
 use EffectiveActivism\SparQlClient\Syntax\Pattern\PatternInterface;
+use EffectiveActivism\SparQlClient\Syntax\Statement\SelectStatementInterface;
 
 interface SubqueryInterface extends PatternInterface
 {
+    public function getInnerStatement(): SelectStatementInterface;
 }

--- a/src/Syntax/Statement/AbstractStatement.php
+++ b/src/Syntax/Statement/AbstractStatement.php
@@ -78,23 +78,26 @@ abstract class AbstractStatement implements StatementInterface
      * Folds namespaces declared on any subquery (recursively) into this
      * statement's own namespace map, so the outer prologue resolves prefixed
      * IRIs that the subquery uses. Throws if the same prefix is bound to
-     * different URLs across the tree.
+     * different URLs across the tree. The merge is atomic: $this->namespaces
+     * is left untouched if any conflict is detected.
      *
      * @throws SparQlException
      */
     protected function mergeSubqueryNamespaces(array $items): void
     {
+        $merged = $this->namespaces;
         foreach ($this->collectSubqueryNamespaces($items) as $prefix => $url) {
-            if (array_key_exists($prefix, $this->namespaces) && $this->namespaces[$prefix] !== $url) {
+            if (array_key_exists($prefix, $merged) && $merged[$prefix] !== $url) {
                 throw new SparQlException(sprintf(
                     'Conflicting namespace declarations for prefix "%s": "%s" and "%s"',
                     $prefix,
-                    $this->namespaces[$prefix],
+                    $merged[$prefix],
                     $url
                 ));
             }
-            $this->namespaces[$prefix] = $url;
+            $merged[$prefix] = $url;
         }
+        $this->namespaces = $merged;
     }
 
     /**

--- a/src/Syntax/Statement/AbstractStatement.php
+++ b/src/Syntax/Statement/AbstractStatement.php
@@ -4,6 +4,7 @@ namespace EffectiveActivism\SparQlClient\Syntax\Statement;
 
 use EffectiveActivism\SparQlClient\Constant;
 use EffectiveActivism\SparQlClient\Exception\SparQlException;
+use EffectiveActivism\SparQlClient\Syntax\Pattern\Subquery\SubqueryInterface;
 use EffectiveActivism\SparQlClient\Syntax\Term\Iri\AbstractIri;
 use EffectiveActivism\SparQlClient\Syntax\Term\Iri\PrefixedIri;
 
@@ -63,6 +64,7 @@ abstract class AbstractStatement implements StatementInterface
      */
     protected function validatePrefixes(array $items): void
     {
+        $this->mergeSubqueryNamespaces($items);
         foreach ($items as $item) {
             foreach ($item->getTerms() as $term) {
                 if (get_class($term) === \EffectiveActivism\SparQlClient\Syntax\Term\Iri\PrefixedIri::class && !in_array($term->getPrefix(), array_keys($this->namespaces))) {
@@ -70,6 +72,58 @@ abstract class AbstractStatement implements StatementInterface
                 }
             }
         }
+    }
+
+    /**
+     * Folds namespaces declared on any subquery (recursively) into this
+     * statement's own namespace map, so the outer prologue resolves prefixed
+     * IRIs that the subquery uses. Throws if the same prefix is bound to
+     * different URLs across the tree.
+     *
+     * @throws SparQlException
+     */
+    protected function mergeSubqueryNamespaces(array $items): void
+    {
+        foreach ($this->collectSubqueryNamespaces($items) as $prefix => $url) {
+            if (array_key_exists($prefix, $this->namespaces) && $this->namespaces[$prefix] !== $url) {
+                throw new SparQlException(sprintf(
+                    'Conflicting namespace declarations for prefix "%s": "%s" and "%s"',
+                    $prefix,
+                    $this->namespaces[$prefix],
+                    $url
+                ));
+            }
+            $this->namespaces[$prefix] = $url;
+        }
+    }
+
+    /**
+     * @throws SparQlException
+     */
+    private function collectSubqueryNamespaces(array $items): array
+    {
+        $collected = [];
+        foreach ($items as $item) {
+            if (!$item instanceof SubqueryInterface) {
+                continue;
+            }
+            $inner = $item->getInnerStatement();
+            $sources = [$inner->getNamespaces(), $this->collectSubqueryNamespaces($inner->getConditions())];
+            foreach ($sources as $source) {
+                foreach ($source as $prefix => $url) {
+                    if (array_key_exists($prefix, $collected) && $collected[$prefix] !== $url) {
+                        throw new SparQlException(sprintf(
+                            'Conflicting namespace declarations for prefix "%s": "%s" and "%s"',
+                            $prefix,
+                            $collected[$prefix],
+                            $url
+                        ));
+                    }
+                    $collected[$prefix] = $url;
+                }
+            }
+        }
+        return $collected;
     }
 
     public function getNamespaces(): array

--- a/tests/Syntax/Pattern/Subquery/SubqueryTest.php
+++ b/tests/Syntax/Pattern/Subquery/SubqueryTest.php
@@ -2,10 +2,12 @@
 
 namespace EffectiveActivism\SparQlClient\Tests\Syntax\Pattern\Subquery;
 
+use EffectiveActivism\SparQlClient\Exception\SparQlException;
 use EffectiveActivism\SparQlClient\Syntax\Pattern\Subquery\Subquery;
 use EffectiveActivism\SparQlClient\Syntax\Pattern\Triple\Triple;
 use EffectiveActivism\SparQlClient\Syntax\Statement\SelectStatement;
 use EffectiveActivism\SparQlClient\Syntax\Term\Iri\Iri;
+use EffectiveActivism\SparQlClient\Syntax\Term\Iri\PrefixedIri;
 use EffectiveActivism\SparQlClient\Syntax\Term\Literal\PlainLiteral;
 use EffectiveActivism\SparQlClient\Syntax\Term\Variable\Variable;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
@@ -54,5 +56,142 @@ class SubqueryTest extends KernelTestCase
         $this->assertStringNotContainsString('BASE', $serialized);
         $this->assertStringNotContainsString('FROM', $serialized);
         $this->assertEquals(self::SERIALIZED_VALUE, $serialized);
+    }
+
+    /**
+     * Inner-statement namespaces propagate to the outer query's prologue,
+     * so callers don't have to duplicate `withNamespaces()` on the outer.
+     *
+     * @covers \EffectiveActivism\SparQlClient\Syntax\Pattern\Subquery\Subquery
+     * @covers \EffectiveActivism\SparQlClient\Syntax\Statement\AbstractStatement
+     * @covers \EffectiveActivism\SparQlClient\Syntax\Statement\SelectStatement
+     */
+    public function testSubqueryPropagatesInnerNamespacesToOuterPrologue()
+    {
+        $subject = new Variable('subject');
+        $object = new Variable('object');
+        $inner = (new SelectStatement([$subject]))
+            ->withNamespaces(['schema' => 'http://schema.org/'])
+            ->where([new Triple($subject, new PrefixedIri('schema', 'headline'), $object)]);
+        $outer = (new SelectStatement([$subject]))
+            ->where([new Subquery($inner)]);
+        $query = $outer->toQuery();
+        $this->assertStringContainsString('PREFIX schema: <http://schema.org/>', $query);
+        $this->assertStringContainsString('schema:headline', $query);
+    }
+
+    /**
+     * Namespaces from a subquery nested inside another subquery bubble up
+     * to the outermost statement's prologue.
+     *
+     * @covers \EffectiveActivism\SparQlClient\Syntax\Pattern\Subquery\Subquery
+     * @covers \EffectiveActivism\SparQlClient\Syntax\Statement\AbstractStatement
+     * @covers \EffectiveActivism\SparQlClient\Syntax\Statement\SelectStatement
+     */
+    public function testNestedSubqueryNamespacesBubbleUp()
+    {
+        $subject = new Variable('subject');
+        $object = new Variable('object');
+        $deep = (new SelectStatement([$subject]))
+            ->withNamespaces(['foaf' => 'http://xmlns.com/foaf/0.1/'])
+            ->where([new Triple($subject, new PrefixedIri('foaf', 'name'), $object)]);
+        $middle = (new SelectStatement([$subject]))
+            ->withNamespaces(['schema' => 'http://schema.org/'])
+            ->where([new Subquery($deep)]);
+        $outer = (new SelectStatement([$subject]))
+            ->where([new Subquery($middle)]);
+        $query = $outer->toQuery();
+        $this->assertStringContainsString('PREFIX foaf: <http://xmlns.com/foaf/0.1/>', $query);
+        $this->assertStringContainsString('PREFIX schema: <http://schema.org/>', $query);
+    }
+
+    /**
+     * The outer's own `withNamespaces()` continues to work alongside
+     * propagation: same prefix bound to the same URL on both sides is fine.
+     *
+     * @covers \EffectiveActivism\SparQlClient\Syntax\Pattern\Subquery\Subquery
+     * @covers \EffectiveActivism\SparQlClient\Syntax\Statement\AbstractStatement
+     * @covers \EffectiveActivism\SparQlClient\Syntax\Statement\SelectStatement
+     */
+    public function testMatchingNamespaceOnInnerAndOuterIsAccepted()
+    {
+        $subject = new Variable('subject');
+        $object = new Variable('object');
+        $inner = (new SelectStatement([$subject]))
+            ->withNamespaces(['schema' => 'http://schema.org/'])
+            ->where([new Triple($subject, new PrefixedIri('schema', 'headline'), $object)]);
+        $outer = (new SelectStatement([$subject]))
+            ->withNamespaces(['schema' => 'http://schema.org/'])
+            ->where([new Subquery($inner)]);
+        $this->assertStringContainsString('PREFIX schema: <http://schema.org/>', $outer->toQuery());
+    }
+
+    /**
+     * Same prefix bound to different URLs across inner and outer is a user
+     * error: refuse to silently pick one.
+     *
+     * @covers \EffectiveActivism\SparQlClient\Syntax\Pattern\Subquery\Subquery
+     * @covers \EffectiveActivism\SparQlClient\Syntax\Statement\AbstractStatement
+     * @covers \EffectiveActivism\SparQlClient\Syntax\Statement\SelectStatement
+     */
+    public function testConflictingNamespaceBetweenInnerAndOuterThrows()
+    {
+        $subject = new Variable('subject');
+        $object = new Variable('object');
+        $inner = (new SelectStatement([$subject]))
+            ->withNamespaces(['schema' => 'http://schema.org/'])
+            ->where([new Triple($subject, new PrefixedIri('schema', 'headline'), $object)]);
+        $outer = (new SelectStatement([$subject]))
+            ->withNamespaces(['schema' => 'http://example.org/wrong/'])
+            ->where([new Subquery($inner)]);
+        $this->expectException(SparQlException::class);
+        $this->expectExceptionMessage('Conflicting namespace declarations for prefix "schema"');
+        $outer->toQuery();
+    }
+
+    /**
+     * Two sibling subqueries declaring the same prefix with different URLs
+     * also conflict.
+     *
+     * @covers \EffectiveActivism\SparQlClient\Syntax\Pattern\Subquery\Subquery
+     * @covers \EffectiveActivism\SparQlClient\Syntax\Statement\AbstractStatement
+     * @covers \EffectiveActivism\SparQlClient\Syntax\Statement\SelectStatement
+     */
+    public function testConflictingNamespaceBetweenSiblingSubqueriesThrows()
+    {
+        $subject = new Variable('subject');
+        $object = new Variable('object');
+        $left = (new SelectStatement([$subject]))
+            ->withNamespaces(['schema' => 'http://schema.org/'])
+            ->where([new Triple($subject, new PrefixedIri('schema', 'headline'), $object)]);
+        $right = (new SelectStatement([$subject]))
+            ->withNamespaces(['schema' => 'http://example.org/other/'])
+            ->where([new Triple($subject, new PrefixedIri('schema', 'name'), $object)]);
+        $outer = (new SelectStatement([$subject]))
+            ->where([new Subquery($left), new Subquery($right)]);
+        $this->expectException(SparQlException::class);
+        $this->expectExceptionMessage('Conflicting namespace declarations for prefix "schema"');
+        $outer->toQuery();
+    }
+
+    /**
+     * A prefix used inside the subquery but declared only on the inner
+     * statement no longer raises 'Prefix … is not defined' on the outer.
+     *
+     * @covers \EffectiveActivism\SparQlClient\Syntax\Pattern\Subquery\Subquery
+     * @covers \EffectiveActivism\SparQlClient\Syntax\Statement\AbstractStatement
+     * @covers \EffectiveActivism\SparQlClient\Syntax\Statement\SelectStatement
+     */
+    public function testValidatePrefixesAcceptsPrefixDeclaredOnlyOnInner()
+    {
+        $subject = new Variable('subject');
+        $object = new Variable('object');
+        $inner = (new SelectStatement([$subject]))
+            ->withNamespaces(['schema' => 'http://schema.org/'])
+            ->where([new Triple($subject, new PrefixedIri('schema', 'headline'), $object)]);
+        $outer = (new SelectStatement([$subject]))
+            ->where([new Subquery($inner)]);
+        $outer->toQuery();
+        $this->assertArrayHasKey('schema', $outer->getNamespaces());
     }
 }

--- a/tests/Syntax/Pattern/Subquery/SubqueryTest.php
+++ b/tests/Syntax/Pattern/Subquery/SubqueryTest.php
@@ -175,6 +175,41 @@ class SubqueryTest extends KernelTestCase
     }
 
     /**
+     * A failed merge must not leave the outer's namespace map partially
+     * mutated: if the conflict trips on the second of two collected
+     * prefixes, the first must not have been written either.
+     *
+     * @covers \EffectiveActivism\SparQlClient\Syntax\Pattern\Subquery\Subquery
+     * @covers \EffectiveActivism\SparQlClient\Syntax\Statement\AbstractStatement
+     * @covers \EffectiveActivism\SparQlClient\Syntax\Statement\SelectStatement
+     */
+    public function testFailedMergeLeavesOuterNamespacesUntouched()
+    {
+        $subject = new Variable('subject');
+        $object = new Variable('object');
+        $inner = (new SelectStatement([$subject]))
+            ->withNamespaces([
+                'foaf' => 'http://xmlns.com/foaf/0.1/',
+                'schema' => 'http://schema.org/',
+            ])
+            ->where([new Triple($subject, new PrefixedIri('schema', 'headline'), $object)]);
+        $outer = (new SelectStatement([$subject]))
+            ->withNamespaces(['schema' => 'http://example.org/wrong/'])
+            ->where([new Subquery($inner)]);
+        try {
+            $outer->toQuery();
+            $this->fail('Expected SparQlException');
+        } catch (SparQlException $exception) {
+            // foaf would have merged before the schema conflict trips,
+            // so a non-atomic merge would surface it on the outer.
+            $this->assertSame(
+                ['schema' => 'http://example.org/wrong/'],
+                $outer->getNamespaces()
+            );
+        }
+    }
+
+    /**
      * A prefix used inside the subquery but declared only on the inner
      * statement no longer raises 'Prefix … is not defined' on the outer.
      *


### PR DESCRIPTION
## Summary

Picks the bubble-up direction from #58: namespaces declared on an inner subquery's statement are merged into the outer query's prologue at serialization time, so callers don't have to duplicate `withNamespaces()` on the outermost statement to make a prefixed IRI inside a subquery resolve.

- `SubqueryInterface::getInnerStatement()` exposes the wrapped `SelectStatementInterface` so the outer can collect namespaces from it.
- `AbstractStatement::validatePrefixes()` now calls a new `mergeSubqueryNamespaces()` step that walks the items list, descends into any `SubqueryInterface` (recursively, for nested subqueries), and folds the inner namespaces into `$this->namespaces`.
- Conflict policy is throw: same prefix bound to different URLs across outer/inner or sibling subqueries raises `SparQlException`. Same prefix bound to the same URL is a no-op.
- `validatePrefixes()` consequently no longer fails with `Prefix "…" is not defined` for prefixes declared only on an inner subquery, since the merge runs first.

The mutation is on the outer statement only; inner statements' namespace maps are unchanged. `Subquery::serialize()` still calls `toSubQuery()`, so `BASE` / `PREFIX` / `FROM` / `FROM NAMED` continue to be stripped from the embedded SubSelect — the inner's `withNamespaces()` only contributes namespaces to the outer prologue.

Scope note: only `Subquery` patterns held directly in `$conditions` (or transitively in another subquery's conditions) are walked. A `Subquery` wrapped inside `Optional` / `FilterNotExists` / `Union` / `Graph` / `Service` is not traversed — those containers don't expose their inner patterns. If that case shows up, it can be a follow-up.

Closes #58.

## Test plan

- [x] New: inner-only `withNamespaces()` propagates to outer prologue.
- [x] New: nested subquery (3-deep) propagates all namespaces to outermost prologue.
- [x] New: matching prefix-URL pair on inner and outer is accepted.
- [x] New: conflicting prefix between inner and outer throws.
- [x] New: conflicting prefix between two sibling subqueries throws.
- [x] New: prefix declared only on inner no longer trips outer `validatePrefixes()`.
- [x] `vendor/bin/phpunit` — full suite, 455 tests, 843 assertions, passing.
- [x] Coverage at 100% (`phpunit-threshold.php`).