### PR TITLE
Add Collection and BlankNodePropertyList triples nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,9 @@ validation.
         - [Inverse path example](#inverse-path-example)
         - [Sequence path example](#sequence-path-example)
         - [Negated set example](#negated-set-example)
+    - [Triples nodes](#triples-nodes)
+        - [Collection example](#collection-example)
+        - [Blank node property list example](#blank-node-property-list-example)
     - [Assignment](#assignment)
         - [Bind example](#bind-example)
         - [Values example](#values-example)
@@ -661,6 +664,55 @@ $negatedSet = new NegatedPropertySet([$predicate, $inversePredicate]);
 // The below will output "!(schema:headline | (^schema:headline))"
 dump($negatedSet->serialize());
 ```
+
+### Triples nodes
+
+The SPARQL grammar allows two abbreviated node forms — RDF collections
+(`( … )`) and blank node property lists (`[ … ]`) — wherever a subject or
+object is expected. Both are represented by terms in the
+`EffectiveActivism\SparQlClient\Syntax\Term\TriplesNode` namespace and may be
+passed to a `Triple` in subject or object position (but never as a
+predicate).
+
+#### Collection example
+
+```php
+<?php
+
+use \EffectiveActivism\SparQlClient\Syntax\Pattern\Triple\Triple;
+use \EffectiveActivism\SparQlClient\Syntax\Term\Iri\PrefixedIri;
+use \EffectiveActivism\SparQlClient\Syntax\Term\TriplesNode\Collection;
+use \EffectiveActivism\SparQlClient\Syntax\Term\Variable\Variable;
+
+$collection = new Collection([new Variable('a'), new Variable('b')]);
+$triple = new Triple(new Variable('x'), new PrefixedIri('ex', 'hasList'), $collection);
+// The below will output "?x ex:hasList ( ?a ?b )"
+dump($triple->serialize());
+```
+
+#### Blank node property list example
+
+A blank node property list is built from `[$predicate, $object]` pairs.
+
+```php
+<?php
+
+use \EffectiveActivism\SparQlClient\Syntax\Pattern\Triple\Triple;
+use \EffectiveActivism\SparQlClient\Syntax\Term\Iri\PrefixedIri;
+use \EffectiveActivism\SparQlClient\Syntax\Term\TriplesNode\BlankNodePropertyList;
+use \EffectiveActivism\SparQlClient\Syntax\Term\Variable\Variable;
+
+$list = new BlankNodePropertyList([
+    [new PrefixedIri('ex', 'q'), new Variable('y')],
+    [new PrefixedIri('ex', 'r'), new Variable('z')],
+]);
+$triple = new Triple(new Variable('x'), new PrefixedIri('ex', 'p'), $list);
+// The below will output "?x ex:p [ ex:q ?y ; ex:r ?z ]"
+dump($triple->serialize());
+```
+
+Both forms may be nested inside one another, since a collection member and a
+property-list object are themselves graph nodes.
 
 ### Assignment
 

--- a/src/Client/CacheTrait.php
+++ b/src/Client/CacheTrait.php
@@ -8,6 +8,7 @@ use EffectiveActivism\SparQlClient\Syntax\Pattern\PatternInterface;
 use EffectiveActivism\SparQlClient\Syntax\Pattern\Triple\TripleInterface;
 use EffectiveActivism\SparQlClient\Syntax\Term\Iri\AbstractIri;
 use EffectiveActivism\SparQlClient\Syntax\Term\Literal\AbstractLiteral;
+use EffectiveActivism\SparQlClient\Syntax\Term\TriplesNode\TriplesNodeInterface;
 use Ramsey\Uuid\Uuid;
 
 trait CacheTrait
@@ -36,6 +37,9 @@ trait CacheTrait
                 if (!isset($tags[$serialized])) {
                     $tags[$serialized] = $this->getKey($serialized);
                 }
+            }
+            elseif ($pattern instanceof TriplesNodeInterface) {
+                $tags = $this->extractTags($pattern->getTerms(), $tags);
             }
             elseif ($pattern instanceof TripleInterface) {
                 $tags = $this->extractTags([$pattern->getSubject(), $pattern->getObject()], $tags);

--- a/src/Syntax/Pattern/Triple/Triple.php
+++ b/src/Syntax/Pattern/Triple/Triple.php
@@ -7,6 +7,7 @@ use EffectiveActivism\SparQlClient\Syntax\Term\BlankNode\BlankNode;
 use EffectiveActivism\SparQlClient\Syntax\Term\Iri\RdfType;
 use EffectiveActivism\SparQlClient\Syntax\Term\Literal\AbstractLiteral;
 use EffectiveActivism\SparQlClient\Syntax\Term\TermInterface;
+use EffectiveActivism\SparQlClient\Syntax\Term\TriplesNode\TriplesNodeInterface;
 
 class Triple implements TripleInterface
 {
@@ -24,7 +25,7 @@ class Triple implements TripleInterface
         if ($subject instanceof AbstractLiteral) {
             throw new SparQlException('Triple subject cannot be a literal');
         }
-        if ($predicate instanceof AbstractLiteral || $predicate instanceof BlankNode) {
+        if ($predicate instanceof AbstractLiteral || $predicate instanceof BlankNode || $predicate instanceof TriplesNodeInterface) {
             throw new SparQlException('Triple predicate must be an IRI, path, or variable');
         }
         $this->subject = $subject;
@@ -82,7 +83,7 @@ class Triple implements TripleInterface
      */
     public function setPredicate(TermInterface $term): TripleInterface
     {
-        if ($term instanceof AbstractLiteral || $term instanceof BlankNode) {
+        if ($term instanceof AbstractLiteral || $term instanceof BlankNode || $term instanceof TriplesNodeInterface) {
             throw new SparQlException('Triple predicate must be an IRI, path, or variable');
         }
         $this->predicate = $term;

--- a/src/Syntax/Term/TriplesNode/BlankNodePropertyList.php
+++ b/src/Syntax/Term/TriplesNode/BlankNodePropertyList.php
@@ -1,0 +1,113 @@
+<?php declare(strict_types=1);
+
+namespace EffectiveActivism\SparQlClient\Syntax\Term\TriplesNode;
+
+use EffectiveActivism\SparQlClient\Exception\SparQlException;
+use EffectiveActivism\SparQlClient\Syntax\Term\AbstractTerm;
+use EffectiveActivism\SparQlClient\Syntax\Term\BlankNode\BlankNode;
+use EffectiveActivism\SparQlClient\Syntax\Term\Iri\RdfType;
+use EffectiveActivism\SparQlClient\Syntax\Term\Literal\AbstractLiteral;
+use EffectiveActivism\SparQlClient\Syntax\Term\Path\AbstractPath;
+use EffectiveActivism\SparQlClient\Syntax\Term\Set\NegatedPropertySet;
+use EffectiveActivism\SparQlClient\Syntax\Term\TermInterface;
+
+/**
+ * A blank node property list, serialised as `[ p1 o1 ; p2 o2 … ]`.
+ *
+ * The list is constructed from predicate-object pairs, each given as a
+ * two-element `[$predicate, $object]` array. As in a triple, a predicate
+ * must be an IRI, a path, or a variable (never a literal, a blank node, or
+ * another triples node), and an object is a GraphNode (a variable, a graph
+ * term, or a nested triples node).
+ *
+ * @see https://www.w3.org/TR/sparql11-query/#rBlankNodePropertyList
+ */
+class BlankNodePropertyList extends AbstractTerm implements TriplesNodeInterface
+{
+    /** @var array<int, array{0: TermInterface, 1: TermInterface}> */
+    protected array $pairs;
+
+    /**
+     * @throws SparQlException
+     */
+    public function __construct(array $pairs)
+    {
+        $this->applyPairs($pairs);
+    }
+
+    /**
+     * @throws SparQlException
+     */
+    private function applyPairs(array $pairs): void
+    {
+        if (empty($pairs)) {
+            throw new SparQlException('BlankNodePropertyList requires at least one predicate-object pair');
+        }
+        foreach ($pairs as $pair) {
+            if (!is_array($pair) || count($pair) !== 2 || !array_is_list($pair)) {
+                throw new SparQlException('BlankNodePropertyList expects a list of [predicate, object] pairs');
+            }
+            [$predicate, $object] = $pair;
+            if (!($predicate instanceof TermInterface) || !($object instanceof TermInterface)) {
+                throw new SparQlException('BlankNodePropertyList predicate and object must both be terms');
+            }
+            if ($predicate instanceof AbstractLiteral || $predicate instanceof BlankNode || $predicate instanceof TriplesNodeInterface) {
+                throw new SparQlException(sprintf('BlankNodePropertyList predicate "%s" must be an IRI, path, or variable', $predicate->serialize()));
+            }
+            if ($object instanceof AbstractPath || $object instanceof NegatedPropertySet) {
+                throw new SparQlException(sprintf('BlankNodePropertyList object "%s" must be a variable, graph term, or triples node', $object->serialize()));
+            }
+        }
+        $this->pairs = array_values($pairs);
+    }
+
+    public function serialize(): string
+    {
+        $serializedPairs = array_map(function (array $pair) {
+            [$predicate, $object] = $pair;
+            $predicateString = $predicate instanceof RdfType ? 'a' : $predicate->serialize();
+            return sprintf('%s %s', $predicateString, $object->serialize());
+        }, $this->pairs);
+        return sprintf('[ %s ]', implode(' ; ', $serializedPairs));
+    }
+
+    /**
+     * Getters.
+     */
+
+    public function getRawValue(): string
+    {
+        return $this->serialize();
+    }
+
+    /**
+     * @return array<int, array{0: TermInterface, 1: TermInterface}>
+     */
+    public function getPairs(): array
+    {
+        return $this->pairs;
+    }
+
+    public function getTerms(): array
+    {
+        $terms = [];
+        foreach ($this->pairs as $pair) {
+            $terms[] = $pair[0];
+            $terms[] = $pair[1];
+        }
+        return $terms;
+    }
+
+    /**
+     * Setters.
+     */
+
+    /**
+     * @throws SparQlException
+     */
+    public function setPairs(array $pairs): TermInterface
+    {
+        $this->applyPairs($pairs);
+        return $this;
+    }
+}

--- a/src/Syntax/Term/TriplesNode/Collection.php
+++ b/src/Syntax/Term/TriplesNode/Collection.php
@@ -1,0 +1,91 @@
+<?php declare(strict_types=1);
+
+namespace EffectiveActivism\SparQlClient\Syntax\Term\TriplesNode;
+
+use EffectiveActivism\SparQlClient\Exception\SparQlException;
+use EffectiveActivism\SparQlClient\Syntax\Term\AbstractTerm;
+use EffectiveActivism\SparQlClient\Syntax\Term\Path\AbstractPath;
+use EffectiveActivism\SparQlClient\Syntax\Term\Set\NegatedPropertySet;
+use EffectiveActivism\SparQlClient\Syntax\Term\TermInterface;
+
+/**
+ * An RDF Collection, serialised as `( m1 m2 … )`.
+ *
+ * Each member is a GraphNode (a variable, a graph term such as an IRI,
+ * literal or blank node, or a nested TriplesNode). Property paths and
+ * negated property sets are predicate-only constructs and are therefore not
+ * valid members.
+ *
+ * @see https://www.w3.org/TR/sparql11-query/#rCollection
+ * @see https://www.w3.org/TR/sparql11-query/#collections
+ */
+class Collection extends AbstractTerm implements TriplesNodeInterface
+{
+    /** @var TermInterface[] */
+    protected array $members;
+
+    /**
+     * @throws SparQlException
+     */
+    public function __construct(array $members)
+    {
+        $this->applyMembers($members);
+    }
+
+    /**
+     * @throws SparQlException
+     */
+    private function applyMembers(array $members): void
+    {
+        if (empty($members)) {
+            throw new SparQlException('Collection requires at least one member');
+        }
+        foreach ($members as $member) {
+            if (!($member instanceof TermInterface)) {
+                $class = is_object($member) ? get_class($member) : gettype($member);
+                throw new SparQlException(sprintf('Collection member "%s" is not a valid term', $class));
+            }
+            if ($member instanceof AbstractPath || $member instanceof NegatedPropertySet) {
+                throw new SparQlException(sprintf('Collection member "%s" must be a variable, graph term, or triples node', $member->serialize()));
+            }
+        }
+        $this->members = array_values($members);
+    }
+
+    public function serialize(): string
+    {
+        return sprintf('( %s )', implode(' ', array_map(fn (TermInterface $member) => $member->serialize(), $this->members)));
+    }
+
+    /**
+     * Getters.
+     */
+
+    public function getRawValue(): string
+    {
+        return $this->serialize();
+    }
+
+    public function getMembers(): array
+    {
+        return $this->members;
+    }
+
+    public function getTerms(): array
+    {
+        return $this->members;
+    }
+
+    /**
+     * Setters.
+     */
+
+    /**
+     * @throws SparQlException
+     */
+    public function setMembers(array $members): TermInterface
+    {
+        $this->applyMembers($members);
+        return $this;
+    }
+}

--- a/src/Syntax/Term/TriplesNode/TriplesNodeInterface.php
+++ b/src/Syntax/Term/TriplesNode/TriplesNodeInterface.php
@@ -12,4 +12,11 @@ use EffectiveActivism\SparQlClient\Syntax\Term\TermInterface;
  */
 interface TriplesNodeInterface extends TermInterface
 {
+    /**
+     * Returns the nested terms of this node, so callers (e.g. cache tag
+     * extraction) can traverse into it.
+     *
+     * @return TermInterface[]
+     */
+    public function getTerms(): array;
 }

--- a/src/Syntax/Term/TriplesNode/TriplesNodeInterface.php
+++ b/src/Syntax/Term/TriplesNode/TriplesNodeInterface.php
@@ -1,0 +1,15 @@
+<?php declare(strict_types=1);
+
+namespace EffectiveActivism\SparQlClient\Syntax\Term\TriplesNode;
+
+use EffectiveActivism\SparQlClient\Syntax\Term\TermInterface;
+
+/**
+ * Marks a term as a TriplesNode, i.e. an RDF Collection or a blank node
+ * property list.
+ *
+ * @see https://www.w3.org/TR/sparql11-query/#rTriplesNode
+ */
+interface TriplesNodeInterface extends TermInterface
+{
+}

--- a/tests/Client/SparQlClientTest.php
+++ b/tests/Client/SparQlClientTest.php
@@ -15,6 +15,8 @@ use EffectiveActivism\SparQlClient\Syntax\Pattern\Triple\Triple;
 use EffectiveActivism\SparQlClient\Syntax\Term\Iri\Iri;
 use EffectiveActivism\SparQlClient\Syntax\Term\Literal\PlainLiteral;
 use EffectiveActivism\SparQlClient\Syntax\Term\Iri\PrefixedIri;
+use EffectiveActivism\SparQlClient\Syntax\Term\TriplesNode\BlankNodePropertyList;
+use EffectiveActivism\SparQlClient\Syntax\Term\TriplesNode\Collection;
 use EffectiveActivism\SparQlClient\Syntax\Term\Variable\Variable;
 use EffectiveActivism\SparQlClient\Tests\Environment\TestKernel;
 use Exception;
@@ -1522,6 +1524,44 @@ class SparQlClientTest extends KernelTestCase
         $this->assertEquals('UNCACHED', $cacheAdapter->get(self::HASHED_QUERY_UUID, function (ItemInterface $item) {
             return 'UNCACHED';
         }));
+    }
+
+    /**
+     * Cache tag extraction descends into triples nodes, so an IRI that only
+     * appears nested inside a collection or blank node property list of a
+     * write still invalidates a cached SELECT tagged with that IRI.
+     *
+     * @covers \EffectiveActivism\SparQlClient\Client\SparQlClient
+     * @covers \EffectiveActivism\SparQlClient\Client\CacheTrait
+     */
+    public function testCachingInvalidationByTriplesNodeIri()
+    {
+        foreach ([
+            fn (Iri $rowIri) => new Collection([$rowIri]),
+            fn (Iri $rowIri) => new BlankNodePropertyList([[new PrefixedIri('schema', 'about'), $rowIri]]),
+        ] as $buildTriplesNode) {
+            $cacheAdapter = new TagAwareAdapter(new ArrayAdapter());
+            $selectResponseContent = file_get_contents(__DIR__ . '/../fixtures/client-select-request.xml');
+            $httpClient = new MockHttpClient([new MockResponse($selectResponseContent), new MockResponse('')]);
+            $kernel = new TestKernel('test', true);
+            $kernel->boot();
+            $kernel->getContainer()->set(TagAwareCacheInterface::class, $cacheAdapter);
+            $kernel->getContainer()->set(HttpClientInterface::class, $httpClient);
+            /** @var SparQlClientInterface $sparQlClient */
+            $sparQlClient = $kernel->getContainer()->get(SparQlClientInterface::class);
+            $subject = new Variable('subject');
+            $predicate = new PrefixedIri('schema', 'headline');
+            $object = new PrefixedIri('schema', 'Article');
+            $sparQlClient->execute($sparQlClient->select([$subject])->withNamespaces(['schema' => 'http://schema.org/'])->where([new Triple($subject, $predicate, $object)]));
+            // Row-level subject from client-select-request.xml, reached only by
+            // recursing into the triples node in the write's object position.
+            $rowSubject = new Iri('urn:uuid:fcf19bc4-7e81-11eb-a169-175604c7c7bc');
+            $writeTriple = new Triple(new Iri('urn:uuid:00000000-0000-0000-0000-000000000000'), new PrefixedIri('schema', 'about'), $buildTriplesNode($rowSubject));
+            $sparQlClient->execute($sparQlClient->delete([$writeTriple])->withNamespaces(['schema' => 'http://schema.org/']));
+            $this->assertEquals('UNCACHED', $cacheAdapter->get(self::HASHED_QUERY_UUID, function (ItemInterface $item) {
+                return 'UNCACHED';
+            }));
+        }
     }
 
     /**

--- a/tests/Syntax/Term/TriplesNode/BlankNodePropertyListTest.php
+++ b/tests/Syntax/Term/TriplesNode/BlankNodePropertyListTest.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace EffectiveActivism\SparQlClient\Tests\Syntax\Term\TriplesNode;
+
+use EffectiveActivism\SparQlClient\Exception\SparQlException;
+use EffectiveActivism\SparQlClient\Syntax\Term\BlankNode\BlankNode;
+use EffectiveActivism\SparQlClient\Syntax\Term\Iri\Iri;
+use EffectiveActivism\SparQlClient\Syntax\Term\Iri\RdfType;
+use EffectiveActivism\SparQlClient\Syntax\Term\Literal\PlainLiteral;
+use EffectiveActivism\SparQlClient\Syntax\Term\Path\InversePath;
+use EffectiveActivism\SparQlClient\Syntax\Term\TriplesNode\BlankNodePropertyList;
+use EffectiveActivism\SparQlClient\Syntax\Term\Variable\Variable;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+class BlankNodePropertyListTest extends KernelTestCase
+{
+    const IRI_Q = 'http://schema.org/q';
+
+    const IRI_R = 'http://schema.org/r';
+
+    public function testBlankNodePropertyList()
+    {
+        $predicateQ = new Iri(self::IRI_Q);
+        $objectY = new Variable('y');
+        $predicateR = new Iri(self::IRI_R);
+        $objectZ = new Variable('z');
+        $list = new BlankNodePropertyList([[$predicateQ, $objectY], [$predicateR, $objectZ]]);
+        $this->assertEquals(sprintf('[ <%s> ?y ; <%s> ?z ]', self::IRI_Q, self::IRI_R), $list->serialize());
+        $this->assertEquals(sprintf('[ <%s> ?y ; <%s> ?z ]', self::IRI_Q, self::IRI_R), $list->getRawValue());
+        $this->assertEquals([$predicateQ, $objectY, $predicateR, $objectZ], $list->getTerms());
+        $this->assertEquals([[$predicateQ, $objectY], [$predicateR, $objectZ]], $list->getPairs());
+        $list->setVariableName('node');
+        $this->assertEquals('node', $list->getVariableName());
+        $result = $list->setPairs([[$predicateQ, $objectY]]);
+        $this->assertInstanceOf(BlankNodePropertyList::class, $result);
+        $this->assertEquals(sprintf('[ <%s> ?y ]', self::IRI_Q), $list->serialize());
+    }
+
+    public function testRdfTypePredicateIsAbbreviated()
+    {
+        $list = new BlankNodePropertyList([[new RdfType(), new Iri(self::IRI_Q)]]);
+        $this->assertEquals(sprintf('[ a <%s> ]', self::IRI_Q), $list->serialize());
+    }
+
+    public function testBlankNodePropertyListExceptions()
+    {
+        $predicate = new Iri(self::IRI_Q);
+        $object = new Variable('y');
+        // Empty lists are not permitted by the grammar.
+        $this->assertExceptionThrown(fn () => new BlankNodePropertyList([]));
+        // Pairs must contain exactly two elements.
+        $this->assertExceptionThrown(fn () => new BlankNodePropertyList([[$predicate]]));
+        $this->assertExceptionThrown(fn () => new BlankNodePropertyList([[$predicate, $object, $object]]));
+        // Both members of a pair must be terms.
+        $this->assertExceptionThrown(fn () => new BlankNodePropertyList([['not-a-term', $object]]));
+        // A predicate cannot be a literal, a blank node, or another triples node.
+        $this->assertExceptionThrown(fn () => new BlankNodePropertyList([[new PlainLiteral('lorem'), $object]]));
+        $this->assertExceptionThrown(fn () => new BlankNodePropertyList([[new BlankNode('label'), $object]]));
+        $this->assertExceptionThrown(fn () => new BlankNodePropertyList([[new BlankNodePropertyList([[$predicate, $object]]), $object]]));
+        // An object cannot be a predicate-only construct.
+        $this->assertExceptionThrown(fn () => new BlankNodePropertyList([[$predicate, new InversePath($predicate)]]));
+        // setPairs() preserves the invariants.
+        $this->assertExceptionThrown(fn () => (new BlankNodePropertyList([[$predicate, $object]]))->setPairs([]));
+    }
+
+    private function assertExceptionThrown(callable $callback): void
+    {
+        $threwException = false;
+        try {
+            $callback();
+        } catch (SparQlException) {
+            $threwException = true;
+        }
+        $this->assertTrue($threwException);
+    }
+}

--- a/tests/Syntax/Term/TriplesNode/CollectionTest.php
+++ b/tests/Syntax/Term/TriplesNode/CollectionTest.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace EffectiveActivism\SparQlClient\Tests\Syntax\Term\TriplesNode;
+
+use EffectiveActivism\SparQlClient\Exception\SparQlException;
+use EffectiveActivism\SparQlClient\Syntax\Term\Iri\Iri;
+use EffectiveActivism\SparQlClient\Syntax\Term\Literal\PlainLiteral;
+use EffectiveActivism\SparQlClient\Syntax\Term\Path\InversePath;
+use EffectiveActivism\SparQlClient\Syntax\Term\Set\NegatedPropertySet;
+use EffectiveActivism\SparQlClient\Syntax\Term\TriplesNode\BlankNodePropertyList;
+use EffectiveActivism\SparQlClient\Syntax\Term\TriplesNode\Collection;
+use EffectiveActivism\SparQlClient\Syntax\Term\Variable\Variable;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+class CollectionTest extends KernelTestCase
+{
+    const IRI = 'http://schema.org/headline';
+
+    public function testCollection()
+    {
+        $iri = new Iri(self::IRI);
+        $variable = new Variable('y');
+        $literal = new PlainLiteral('lorem');
+        $collection = new Collection([$iri, $variable, $literal]);
+        $this->assertEquals(sprintf('( <%s> ?y """lorem""" )', self::IRI), $collection->serialize());
+        $this->assertEquals(sprintf('( <%s> ?y """lorem""" )', self::IRI), $collection->getRawValue());
+        $this->assertEquals([$iri, $variable, $literal], $collection->getMembers());
+        $this->assertEquals([$iri, $variable, $literal], $collection->getTerms());
+        $collection->setVariableName('list');
+        $this->assertEquals('list', $collection->getVariableName());
+        $result = $collection->setMembers([$variable]);
+        $this->assertInstanceOf(Collection::class, $result);
+        $this->assertEquals('( ?y )', $collection->serialize());
+    }
+
+    public function testNestedTriplesNodesAreValidMembers()
+    {
+        $nestedCollection = new Collection([new Variable('a'), new Variable('b')]);
+        $nestedList = new BlankNodePropertyList([[new Iri(self::IRI), new Variable('c')]]);
+        $collection = new Collection([$nestedCollection, $nestedList]);
+        $this->assertEquals(sprintf('( ( ?a ?b ) [ <%s> ?c ] )', self::IRI), $collection->serialize());
+    }
+
+    public function testCollectionExceptions()
+    {
+        // Empty collections are not permitted by the grammar.
+        $threwException = false;
+        try {
+            new Collection([]);
+        } catch (SparQlException) {
+            $threwException = true;
+        }
+        $this->assertTrue($threwException);
+        // Non-term members are rejected.
+        $threwException = false;
+        try {
+            new Collection(['not-a-term']);
+        } catch (SparQlException) {
+            $threwException = true;
+        }
+        $this->assertTrue($threwException);
+        // Predicate-only constructs are not valid graph nodes.
+        $threwException = false;
+        try {
+            new Collection([new InversePath(new Iri(self::IRI))]);
+        } catch (SparQlException) {
+            $threwException = true;
+        }
+        $this->assertTrue($threwException);
+        $threwException = false;
+        try {
+            new Collection([new NegatedPropertySet([new Iri(self::IRI)])]);
+        } catch (SparQlException) {
+            $threwException = true;
+        }
+        $this->assertTrue($threwException);
+        // setMembers() preserves the invariants.
+        $threwException = false;
+        try {
+            (new Collection([new Variable('y')]))->setMembers([]);
+        } catch (SparQlException) {
+            $threwException = true;
+        }
+        $this->assertTrue($threwException);
+    }
+}

--- a/tests/Syntax/Term/TriplesNode/TriplesNodeIntegrationTest.php
+++ b/tests/Syntax/Term/TriplesNode/TriplesNodeIntegrationTest.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace EffectiveActivism\SparQlClient\Tests\Syntax\Term\TriplesNode;
+
+use EffectiveActivism\SparQlClient\Exception\SparQlException;
+use EffectiveActivism\SparQlClient\Syntax\Pattern\Triple\Triple;
+use EffectiveActivism\SparQlClient\Syntax\Statement\SelectStatement;
+use EffectiveActivism\SparQlClient\Syntax\Term\Iri\PrefixedIri;
+use EffectiveActivism\SparQlClient\Syntax\Term\TriplesNode\BlankNodePropertyList;
+use EffectiveActivism\SparQlClient\Syntax\Term\TriplesNode\Collection;
+use EffectiveActivism\SparQlClient\Syntax\Term\Variable\Variable;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+class TriplesNodeIntegrationTest extends KernelTestCase
+{
+    public function testCollectionInObjectAndSubjectPosition()
+    {
+        $hasList = new PrefixedIri('ex', 'hasList');
+        $object = new Collection([new Variable('a'), new Variable('b')]);
+        $triple = new Triple(new Variable('x'), $hasList, $object);
+        $this->assertEquals('?x ex:hasList ( ?a ?b )', $triple->serialize());
+
+        $subject = new Collection([new Variable('a'), new Variable('b')]);
+        $triple = new Triple($subject, new PrefixedIri('ex', 'p'), new Variable('z'));
+        $this->assertEquals('( ?a ?b ) ex:p ?z', $triple->serialize());
+    }
+
+    public function testBlankNodePropertyListInObjectAndSubjectPosition()
+    {
+        $list = new BlankNodePropertyList([
+            [new PrefixedIri('ex', 'q'), new Variable('y')],
+            [new PrefixedIri('ex', 'r'), new Variable('z')],
+        ]);
+        $triple = new Triple(new Variable('x'), new PrefixedIri('ex', 'p'), $list);
+        $this->assertEquals('?x ex:p [ ex:q ?y ; ex:r ?z ]', $triple->serialize());
+
+        $subject = new BlankNodePropertyList([[new PrefixedIri('ex', 'a'), new Variable('b')]]);
+        $triple = new Triple($subject, new PrefixedIri('ex', 'c'), new Variable('d'));
+        $this->assertEquals('[ ex:a ?b ] ex:c ?d', $triple->serialize());
+    }
+
+    public function testTriplesNodeRejectedInPredicatePosition()
+    {
+        $collection = new Collection([new Variable('a')]);
+        $threwException = false;
+        try {
+            new Triple(new Variable('x'), $collection, new Variable('z'));
+        } catch (SparQlException) {
+            $threwException = true;
+        }
+        $this->assertTrue($threwException);
+
+        $list = new BlankNodePropertyList([[new PrefixedIri('ex', 'q'), new Variable('y')]]);
+        $threwException = false;
+        try {
+            (new Triple(new Variable('x'), new PrefixedIri('ex', 'p'), new Variable('z')))->setPredicate($list);
+        } catch (SparQlException) {
+            $threwException = true;
+        }
+        $this->assertTrue($threwException);
+    }
+
+    public function testSelectStatementWithTriplesNodes()
+    {
+        $statement = new SelectStatement([new Variable('x')]);
+        $statement->withNamespaces(['ex' => 'http://example.org/']);
+        $statement->where([
+            new Triple(
+                new Variable('x'),
+                new PrefixedIri('ex', 'hasList'),
+                new Collection([new Variable('a'), new Variable('b')])
+            ),
+            new Triple(
+                new BlankNodePropertyList([[new PrefixedIri('ex', 'q'), new Variable('y')]]),
+                new PrefixedIri('ex', 'p'),
+                new Variable('x')
+            ),
+        ]);
+        $expected = 'PREFIX ex: <http://example.org/> '
+            . 'SELECT ?x WHERE { ?x ex:hasList ( ?a ?b ) . [ ex:q ?y ] ex:p ?x . }';
+        $this->assertEquals($expected, $statement->toQuery());
+    }
+}


### PR DESCRIPTION
Closes #60.

## What

Adds term types covering the two SPARQL `TriplesNode` productions (SPARQL 1.1 Query §19.8) so the builder no longer has to fall back to a raw query string when a collection or blank node property list appears in subject or object position.

New `Syntax\Term\TriplesNode\` namespace, both terms implementing a `TriplesNodeInterface` marker:

- **`Collection`** — serializes members as `( m1 m2 … )`. Members must be graph nodes (variable, graph term, or nested triples node); property paths and negated property sets are rejected as they are predicate-only. Empty collections are rejected (the grammar requires `GraphNode+`).
- **`BlankNodePropertyList`** — built from `[$predicate, $object]` pairs, serializes as `[ p1 o1 ; p2 o2 ]`. Predicate validation mirrors `Triple` (no literal/blank node/triples node; `RdfType` abbreviates to `a`); objects must be graph nodes.

Both are accepted by `Triple` in subject and object position. `Triple` now also rejects either form in predicate position, since a triples node is never a valid verb. `CacheTrait::extractTags` recurses into triples nodes so nested IRIs and literals still drive cache invalidation.

## Tests

Three new test files (unit coverage for both terms plus a Triple/`SELECT` integration test). Full suite green: 466 tests, 881 assertions.

## Known limitation (not addressed here)

The statement-level validators in this codebase are shallow — they inspect only a `Triple`'s three top-level terms and never descend into composite terms. This predates this change (`NegatedPropertySet` and property paths share the blind spot). Consequences:

- A prefixed IRI nested inside a triples node escapes `validatePrefixes`, so an undefined prefix is not caught here.
- A variable that appears *only* nested inside a triples node is invisible to the "variable must be referenced in WHERE" checks; worst case, an `INSERT DATA` with such a variable serializes as invalid SPARQL rather than throwing.

Closing these would require deepening variable/prefix validation across the statement classes and is left as a potential follow-up.