### PR TITLE
Accept numeric literals in arithmetic and operators in Not

### DIFF
--- a/src/Syntax/Pattern/Constraint/Operator/Binary/AbstractBinaryOperator.php
+++ b/src/Syntax/Pattern/Constraint/Operator/Binary/AbstractBinaryOperator.php
@@ -32,7 +32,9 @@ abstract class AbstractBinaryOperator implements BinaryOperatorInterface
     {
         foreach ([$leftExpression, $rightExpression] as $expression) {
             if ($expression instanceof AbstractLiteral && !in_array($expression->getType(), self::NUMERIC_TYPES, true)) {
-                throw new SparQlException(sprintf('Type error: "%s" and "%s" must be numeric or a variable', $leftExpression->getRawValue(), $rightExpression->getRawValue()));
+                // serialize() rather than getRawValue(): an operand may be an
+                // OperatorInterface, which has no getRawValue().
+                throw new SparQlException(sprintf('Type error: "%s" and "%s" must be numeric or a variable', $leftExpression->serialize(), $rightExpression->serialize()));
             }
         }
     }

--- a/src/Syntax/Pattern/Constraint/Operator/Binary/AbstractBinaryOperator.php
+++ b/src/Syntax/Pattern/Constraint/Operator/Binary/AbstractBinaryOperator.php
@@ -2,14 +2,40 @@
 
 namespace EffectiveActivism\SparQlClient\Syntax\Pattern\Constraint\Operator\Binary;
 
+use EffectiveActivism\SparQlClient\Exception\SparQlException;
 use EffectiveActivism\SparQlClient\Syntax\Pattern\Constraint\Operator\OperatorInterface;
+use EffectiveActivism\SparQlClient\Syntax\Term\Literal\AbstractLiteral;
 use EffectiveActivism\SparQlClient\Syntax\Term\TermInterface;
 
 abstract class AbstractBinaryOperator implements BinaryOperatorInterface
 {
+    /**
+     * The XSD numeric type hierarchy that the arithmetic operators accept as
+     * literal operands.
+     *
+     * @see https://www.w3.org/TR/sparql11-query/#operandDataTypes
+     */
+    protected const NUMERIC_TYPES = ['xsd:integer', 'xsd:decimal', 'xsd:float', 'xsd:double'];
+
     protected OperatorInterface|TermInterface $leftExpression;
 
     protected OperatorInterface|TermInterface $rightExpression;
+
+    /**
+     * Rejects literal operands that are not numeric. Non-literal operands
+     * (variables, nested operators) are left to the endpoint to type-check at
+     * evaluation time.
+     *
+     * @throws SparQlException
+     */
+    protected function assertNumericOperands(OperatorInterface|TermInterface $leftExpression, OperatorInterface|TermInterface $rightExpression): void
+    {
+        foreach ([$leftExpression, $rightExpression] as $expression) {
+            if ($expression instanceof AbstractLiteral && !in_array($expression->getType(), self::NUMERIC_TYPES, true)) {
+                throw new SparQlException(sprintf('Type error: "%s" and "%s" must be numeric or a variable', $leftExpression->getRawValue(), $rightExpression->getRawValue()));
+            }
+        }
+    }
 
     public function getLeftExpression(): OperatorInterface|TermInterface
     {

--- a/src/Syntax/Pattern/Constraint/Operator/Binary/Add.php
+++ b/src/Syntax/Pattern/Constraint/Operator/Binary/Add.php
@@ -4,22 +4,18 @@ namespace EffectiveActivism\SparQlClient\Syntax\Pattern\Constraint\Operator\Bina
 
 use EffectiveActivism\SparQlClient\Exception\SparQlException;
 use EffectiveActivism\SparQlClient\Syntax\Pattern\Constraint\Operator\OperatorInterface;
-use EffectiveActivism\SparQlClient\Syntax\Term\Literal\AbstractLiteral;
 use EffectiveActivism\SparQlClient\Syntax\Term\TermInterface;
 
 class Add extends AbstractBinaryOperator implements BinaryOperatorInterface
 {
     /**
      * @see http://www.w3.org/TR/xpath-functions/#func-numeric-add.
+     *
+     * @throws SparQlException
      */
     public function __construct(OperatorInterface|TermInterface $leftExpression, OperatorInterface|TermInterface $rightExpression)
     {
-        if (
-            ($leftExpression instanceof AbstractLiteral && $leftExpression->getType() !== 'xsd:integer') ||
-            ($rightExpression instanceof AbstractLiteral && $rightExpression->getType() !== 'xsd:integer')
-        ) {
-            throw new SparQlException(sprintf('Type error: "%s" and "%s" must be of type xsd:integer or a variable', $leftExpression->getRawValue(), $rightExpression->getRawValue()));
-        }
+        $this->assertNumericOperands($leftExpression, $rightExpression);
         $this->leftExpression = $leftExpression;
         $this->rightExpression = $rightExpression;
     }

--- a/src/Syntax/Pattern/Constraint/Operator/Binary/Divide.php
+++ b/src/Syntax/Pattern/Constraint/Operator/Binary/Divide.php
@@ -4,23 +4,18 @@ namespace EffectiveActivism\SparQlClient\Syntax\Pattern\Constraint\Operator\Bina
 
 use EffectiveActivism\SparQlClient\Exception\SparQlException;
 use EffectiveActivism\SparQlClient\Syntax\Pattern\Constraint\Operator\OperatorInterface;
-use EffectiveActivism\SparQlClient\Syntax\Term\Literal\AbstractLiteral;
 use EffectiveActivism\SparQlClient\Syntax\Term\TermInterface;
-use EffectiveActivism\SparQlClient\Syntax\Term\Variable\Variable;
 
 class Divide extends AbstractBinaryOperator implements BinaryOperatorInterface
 {
     /**
      * @see http://www.w3.org/TR/xpath-functions/#func-numeric-divide.
+     *
+     * @throws SparQlException
      */
     public function __construct(OperatorInterface|TermInterface $leftExpression, OperatorInterface|TermInterface $rightExpression)
     {
-        if (
-            ($leftExpression instanceof AbstractLiteral && $leftExpression->getType() !== 'xsd:integer') ||
-            ($rightExpression instanceof AbstractLiteral && $rightExpression->getType() !== 'xsd:integer')
-        ) {
-            throw new SparQlException(sprintf('Type error: "%s" and "%s" must be of type xsd:integer or a variable', $leftExpression->getRawValue(), $rightExpression->getRawValue()));
-        }
+        $this->assertNumericOperands($leftExpression, $rightExpression);
         $this->leftExpression = $leftExpression;
         $this->rightExpression = $rightExpression;
     }

--- a/src/Syntax/Pattern/Constraint/Operator/Binary/Multiply.php
+++ b/src/Syntax/Pattern/Constraint/Operator/Binary/Multiply.php
@@ -4,23 +4,18 @@ namespace EffectiveActivism\SparQlClient\Syntax\Pattern\Constraint\Operator\Bina
 
 use EffectiveActivism\SparQlClient\Exception\SparQlException;
 use EffectiveActivism\SparQlClient\Syntax\Pattern\Constraint\Operator\OperatorInterface;
-use EffectiveActivism\SparQlClient\Syntax\Term\Literal\AbstractLiteral;
 use EffectiveActivism\SparQlClient\Syntax\Term\TermInterface;
-use EffectiveActivism\SparQlClient\Syntax\Term\Variable\Variable;
 
 class Multiply extends AbstractBinaryOperator implements BinaryOperatorInterface
 {
     /**
      * @see http://www.w3.org/TR/xpath-functions/#func-numeric-multiply.
+     *
+     * @throws SparQlException
      */
     public function __construct(OperatorInterface|TermInterface $leftExpression, OperatorInterface|TermInterface $rightExpression)
     {
-        if (
-            ($leftExpression instanceof AbstractLiteral && $leftExpression->getType() !== 'xsd:integer') ||
-            ($rightExpression instanceof AbstractLiteral && $rightExpression->getType() !== 'xsd:integer')
-        ) {
-            throw new SparQlException(sprintf('Type error: "%s" and "%s" must be of type xsd:integer or a variable', $leftExpression->getRawValue(), $rightExpression->getRawValue()));
-        }
+        $this->assertNumericOperands($leftExpression, $rightExpression);
         $this->leftExpression = $leftExpression;
         $this->rightExpression = $rightExpression;
     }

--- a/src/Syntax/Pattern/Constraint/Operator/Binary/Substract.php
+++ b/src/Syntax/Pattern/Constraint/Operator/Binary/Substract.php
@@ -4,23 +4,18 @@ namespace EffectiveActivism\SparQlClient\Syntax\Pattern\Constraint\Operator\Bina
 
 use EffectiveActivism\SparQlClient\Exception\SparQlException;
 use EffectiveActivism\SparQlClient\Syntax\Pattern\Constraint\Operator\OperatorInterface;
-use EffectiveActivism\SparQlClient\Syntax\Term\Literal\AbstractLiteral;
 use EffectiveActivism\SparQlClient\Syntax\Term\TermInterface;
-use EffectiveActivism\SparQlClient\Syntax\Term\Variable\Variable;
 
 class Substract extends AbstractBinaryOperator implements BinaryOperatorInterface
 {
     /**
      * @see http://www.w3.org/TR/xpath-functions/#func-numeric-substract
+     *
+     * @throws SparQlException
      */
     public function __construct(OperatorInterface|TermInterface $leftExpression, OperatorInterface|TermInterface $rightExpression)
     {
-        if (
-            ($leftExpression instanceof AbstractLiteral && $leftExpression->getType() !== 'xsd:integer') ||
-            ($rightExpression instanceof AbstractLiteral && $rightExpression->getType() !== 'xsd:integer')
-        ) {
-            throw new SparQlException(sprintf('Type error: "%s" and "%s" must be of type xsd:integer or a variable', $leftExpression->getRawValue(), $rightExpression->getRawValue()));
-        }
+        $this->assertNumericOperands($leftExpression, $rightExpression);
         $this->leftExpression = $leftExpression;
         $this->rightExpression = $rightExpression;
     }

--- a/src/Syntax/Pattern/Constraint/Operator/Unary/AbstractUnaryOperator.php
+++ b/src/Syntax/Pattern/Constraint/Operator/Unary/AbstractUnaryOperator.php
@@ -2,13 +2,14 @@
 
 namespace EffectiveActivism\SparQlClient\Syntax\Pattern\Constraint\Operator\Unary;
 
+use EffectiveActivism\SparQlClient\Syntax\Pattern\Constraint\Operator\OperatorInterface;
 use EffectiveActivism\SparQlClient\Syntax\Term\TermInterface;
 
 abstract class AbstractUnaryOperator implements UnaryOperatorInterface
 {
-    protected TermInterface $expression;
+    protected OperatorInterface|TermInterface $expression;
 
-    public function getExpression(): TermInterface
+    public function getExpression(): OperatorInterface|TermInterface
     {
         return $this->expression;
     }

--- a/src/Syntax/Pattern/Constraint/Operator/Unary/Not.php
+++ b/src/Syntax/Pattern/Constraint/Operator/Unary/Not.php
@@ -2,19 +2,23 @@
 
 namespace EffectiveActivism\SparQlClient\Syntax\Pattern\Constraint\Operator\Unary;
 
-use EffectiveActivism\SparQlClient\Syntax\Term\Iri\AbstractIri;
-use EffectiveActivism\SparQlClient\Syntax\Term\Literal\AbstractLiteral;
-use EffectiveActivism\SparQlClient\Syntax\Term\Variable\Variable;
+use EffectiveActivism\SparQlClient\Syntax\Pattern\Constraint\Operator\OperatorInterface;
+use EffectiveActivism\SparQlClient\Syntax\Term\TermInterface;
 
 class Not extends AbstractUnaryOperator implements UnaryOperatorInterface
 {
-    public function __construct(AbstractIri|AbstractLiteral|Variable $expression)
+    public function __construct(OperatorInterface|TermInterface $expression)
     {
         $this->expression = $expression;
     }
 
     public function serialize(): string
     {
-        return sprintf('! %s', $this->expression->serialize());
+        // Wrap operator operands in parentheses so precedence is preserved,
+        // e.g. "! (?a = ?b)" rather than the mis-parsed "! ?a = ?b".
+        $serializedExpression = $this->expression instanceof OperatorInterface
+            ? sprintf('(%s)', $this->expression->serialize())
+            : $this->expression->serialize();
+        return sprintf('! %s', $serializedExpression);
     }
 }

--- a/tests/Syntax/Pattern/Constraint/Operator/Binary/AddTest.php
+++ b/tests/Syntax/Pattern/Constraint/Operator/Binary/AddTest.php
@@ -4,7 +4,9 @@ namespace EffectiveActivism\SparQlClient\Tests\Syntax\Pattern\Constraint\Operato
 
 use EffectiveActivism\SparQlClient\Exception\SparQlException;
 use EffectiveActivism\SparQlClient\Syntax\Pattern\Constraint\Operator\Binary\Add;
+use EffectiveActivism\SparQlClient\Syntax\Pattern\Constraint\Operator\Unary\Bound;
 use EffectiveActivism\SparQlClient\Syntax\Term\Literal\PlainLiteral;
+use EffectiveActivism\SparQlClient\Syntax\Term\Variable\Variable;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 
 class AddTest extends KernelTestCase
@@ -33,5 +35,15 @@ class AddTest extends KernelTestCase
         $term2 = new PlainLiteral('ipsum');
         $this->expectException(SparQlException::class);
         new Add($term1, $term2);
+    }
+
+    public function testInvalidOperatorWithOperatorOperand()
+    {
+        // The other operand is an operator (no getRawValue()); building the
+        // error message must not fatal — a SparQlException is thrown.
+        $operatorOperand = new Bound(new Variable('x'));
+        $nonNumericLiteral = new PlainLiteral('lorem');
+        $this->expectException(SparQlException::class);
+        new Add($operatorOperand, $nonNumericLiteral);
     }
 }

--- a/tests/Syntax/Pattern/Constraint/Operator/Binary/AddTest.php
+++ b/tests/Syntax/Pattern/Constraint/Operator/Binary/AddTest.php
@@ -11,12 +11,20 @@ class AddTest extends KernelTestCase
 {
     const SERIALIZED_OPERATOR = '"1"^^<http://www.w3.org/2001/XMLSchema#integer> + "2"^^<http://www.w3.org/2001/XMLSchema#integer>';
 
+    const SERIALIZED_DECIMAL_OPERATOR = '"1.5"^^<http://www.w3.org/2001/XMLSchema#decimal> + "2.5"^^<http://www.w3.org/2001/XMLSchema#decimal>';
+
     public function testOperator()
     {
         $term1 = new PlainLiteral(1);
         $term2 = new PlainLiteral(2);
         $operator = new Add($term1, $term2);
         $this->assertEquals(self::SERIALIZED_OPERATOR, $operator->serialize());
+    }
+
+    public function testDecimalOperands()
+    {
+        $operator = new Add(new PlainLiteral(1.5), new PlainLiteral(2.5));
+        $this->assertEquals(self::SERIALIZED_DECIMAL_OPERATOR, $operator->serialize());
     }
 
     public function testInvalidOperator()

--- a/tests/Syntax/Pattern/Constraint/Operator/Binary/DivideTest.php
+++ b/tests/Syntax/Pattern/Constraint/Operator/Binary/DivideTest.php
@@ -11,12 +11,20 @@ class DivideTest extends KernelTestCase
 {
     const SERIALIZED_OPERATOR = '"1"^^<http://www.w3.org/2001/XMLSchema#integer> / "2"^^<http://www.w3.org/2001/XMLSchema#integer>';
 
+    const SERIALIZED_DECIMAL_OPERATOR = '"1.5"^^<http://www.w3.org/2001/XMLSchema#decimal> / "2.5"^^<http://www.w3.org/2001/XMLSchema#decimal>';
+
     public function testOperator()
     {
         $term1 = new PlainLiteral(1);
         $term2 = new PlainLiteral(2);
         $operator = new Divide($term1, $term2);
         $this->assertEquals(self::SERIALIZED_OPERATOR, $operator->serialize());
+    }
+
+    public function testDecimalOperands()
+    {
+        $operator = new Divide(new PlainLiteral(1.5), new PlainLiteral(2.5));
+        $this->assertEquals(self::SERIALIZED_DECIMAL_OPERATOR, $operator->serialize());
     }
 
     public function testInvalidOperator()

--- a/tests/Syntax/Pattern/Constraint/Operator/Binary/MultiplyTest.php
+++ b/tests/Syntax/Pattern/Constraint/Operator/Binary/MultiplyTest.php
@@ -11,12 +11,20 @@ class MultiplyTest extends KernelTestCase
 {
     const SERIALIZED_OPERATOR = '"1"^^<http://www.w3.org/2001/XMLSchema#integer> * "2"^^<http://www.w3.org/2001/XMLSchema#integer>';
 
+    const SERIALIZED_DECIMAL_OPERATOR = '"1.5"^^<http://www.w3.org/2001/XMLSchema#decimal> * "2.5"^^<http://www.w3.org/2001/XMLSchema#decimal>';
+
     public function testOperator()
     {
         $term1 = new PlainLiteral(1);
         $term2 = new PlainLiteral(2);
         $operator = new Multiply($term1, $term2);
         $this->assertEquals(self::SERIALIZED_OPERATOR, $operator->serialize());
+    }
+
+    public function testDecimalOperands()
+    {
+        $operator = new Multiply(new PlainLiteral(1.5), new PlainLiteral(2.5));
+        $this->assertEquals(self::SERIALIZED_DECIMAL_OPERATOR, $operator->serialize());
     }
 
     public function testInvalidOperator()

--- a/tests/Syntax/Pattern/Constraint/Operator/Binary/SubstractTest.php
+++ b/tests/Syntax/Pattern/Constraint/Operator/Binary/SubstractTest.php
@@ -5,11 +5,14 @@ namespace EffectiveActivism\SparQlClient\Tests\Syntax\Pattern\Constraint\Operato
 use EffectiveActivism\SparQlClient\Exception\SparQlException;
 use EffectiveActivism\SparQlClient\Syntax\Pattern\Constraint\Operator\Binary\Substract;
 use EffectiveActivism\SparQlClient\Syntax\Term\Literal\PlainLiteral;
+use EffectiveActivism\SparQlClient\Syntax\Term\Variable\Variable;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 
 class SubstractTest extends KernelTestCase
 {
     const SERIALIZED_OPERATOR = '"1"^^<http://www.w3.org/2001/XMLSchema#integer> - "2"^^<http://www.w3.org/2001/XMLSchema#integer>';
+
+    const SERIALIZED_DECIMAL_OPERATOR = '?lat - "52.13"^^<http://www.w3.org/2001/XMLSchema#decimal>';
 
     public function testOperator()
     {
@@ -17,6 +20,14 @@ class SubstractTest extends KernelTestCase
         $term2 = new PlainLiteral(2);
         $operator = new Substract($term1, $term2);
         $this->assertEquals(self::SERIALIZED_OPERATOR, $operator->serialize());
+    }
+
+    public function testDecimalOperand()
+    {
+        // Decimal (and other numeric) literal operands are accepted, e.g.
+        // for "ABS(?lat - 52.13)" bounding-box arithmetic.
+        $operator = new Substract(new Variable('lat'), new PlainLiteral(52.13));
+        $this->assertEquals(self::SERIALIZED_DECIMAL_OPERATOR, $operator->serialize());
     }
 
     public function testInvalidOperator()

--- a/tests/Syntax/Pattern/Constraint/Operator/Unary/NotTest.php
+++ b/tests/Syntax/Pattern/Constraint/Operator/Unary/NotTest.php
@@ -2,6 +2,7 @@
 
 namespace EffectiveActivism\SparQlClient\Tests\Syntax\Pattern\Constraint\Operator\Unary;
 
+use EffectiveActivism\SparQlClient\Syntax\Pattern\Constraint\Operator\Unary\Bound;
 use EffectiveActivism\SparQlClient\Syntax\Pattern\Constraint\Operator\Unary\Not;
 use EffectiveActivism\SparQlClient\Syntax\Term\Iri\Iri;
 use EffectiveActivism\SparQlClient\Syntax\Term\Literal\PlainLiteral;
@@ -15,6 +16,8 @@ class NotTest extends KernelTestCase
     const SERIALIZED_OPERATOR_VARIABLE = '! ?subject';
 
     const SERIALIZED_OPERATOR_IRI = '! <urn:uuid:a8ea08b2-95f7-11eb-aa9c-23071bcbf225>';
+
+    const SERIALIZED_OPERATOR_OPERATOR = '! (BOUND(?wkt))';
 
     public function testOperator()
     {
@@ -35,6 +38,16 @@ class NotTest extends KernelTestCase
         $iri = new Iri('urn:uuid:a8ea08b2-95f7-11eb-aa9c-23071bcbf225');
         $operator = new Not($iri);
         $this->assertEquals(self::SERIALIZED_OPERATOR_IRI, $operator->serialize());
+    }
+
+    public function testOperatorWithOperator()
+    {
+        // Negating a built-in call, e.g. "!BOUND(?wkt)". The operand is an
+        // operator, so it is parenthesised to preserve precedence.
+        $bound = new Bound(new Variable('wkt'));
+        $operator = new Not($bound);
+        $this->assertEquals(self::SERIALIZED_OPERATOR_OPERATOR, $operator->serialize());
+        $this->assertEquals($bound, $operator->getExpression());
     }
 
     public function testGetExpression()


### PR DESCRIPTION
Closes #62.

## Problem

The expression-operator classes validate operand types inconsistently, blocking standard SPARQL expressions:

- **Arithmetic** (`Add`, `Substract`, `Multiply`, `Divide`) rejected any literal operand whose type was not exactly `xsd:integer`, so `ABS(?lat - 52.13)` (decimal/bounding-box arithmetic) was unbuildable — despite the cited xpath-functions specs being defined over the whole numeric hierarchy.
- **`Not`** accepted only `AbstractIri|AbstractLiteral|Variable`, so `!BOUND(?wkt)` (and `!REGEX(...)`, `!isLiteral(...)`, …) could not be constructed, even though `UnaryOperatorInterface::getExpression()` already declares `OperatorInterface|TermInterface`.
- For contrast, the comparison operators already only reject literal-vs-literal type mismatches, so `?lat < 52.13` worked — the asymmetry this PR removes.

## Changes

- Factor a shared `assertNumericOperands()` into `AbstractBinaryOperator` accepting `xsd:integer`, `xsd:decimal`, `xsd:float`, `xsd:double`; the four arithmetic operators use it. Non-numeric literals (string, boolean, date/time) are still rejected.
- Widen `AbstractUnaryOperator`'s `$expression` property and `getExpression()` return to `OperatorInterface|TermInterface` (aligning the implementation with its own interface), and widen `Not`'s constructor accordingly. `Not::serialize()` parenthesises operator operands so precedence is preserved (`! (?a = ?b)`, `! (BOUND(?wkt))`).

## Tests

Added decimal-operand coverage to the four arithmetic operator tests (e.g. `?lat - 52.13`) and a `Not`-wrapping-`BOUND` case. Full suite green at 461 tests; 100% line coverage maintained.

## Compatibility

Both changes are **widening only** — inputs that previously threw are now accepted; nothing previously valid becomes invalid. The `getExpression()` return widening aligns the abstract class with the interface it already implements. Backward compatible (minor version).